### PR TITLE
Rebuild scanroot tree preseve state

### DIFF
--- a/DuplicateFileFinder.Gui/Features/Duplicates/Application/DuplicateExplorerSelectionContext.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/Application/DuplicateExplorerSelectionContext.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace DuplicateFileFinder.Gui.Features.Duplicates.Application;
@@ -5,6 +7,8 @@ namespace DuplicateFileFinder.Gui.Features.Duplicates.Application;
 public sealed class DuplicateExplorerSelectionContext : ObservableObject
 {
     private SelectionTarget? _current;
+    private int _notificationSuppressionCount;
+    private bool _currentChangedDuringSuppression;
 
     public SelectionTarget? Current
     {
@@ -14,28 +18,81 @@ public sealed class DuplicateExplorerSelectionContext : ObservableObject
 
     public void SetCurrent(SelectionTarget? value, bool forceNotify = false)
     {
-        if (!forceNotify && Nullable.Equals(_current, value))
+        var changed = !Nullable.Equals(_current, value);
+
+        if (!changed && !forceNotify)
             return;
 
         _current = value;
 
+        if (_notificationSuppressionCount > 0)
+        {
+            if (changed || forceNotify)
+                _currentChangedDuringSuppression = true;
+
+            return;
+        }
+
         OnPropertyChanged(nameof(Current));
+    }
+
+    public IDisposable SuspendNotifications()
+    {
+        _notificationSuppressionCount++;
+        return new NotificationSuspension(this);
+    }
+
+    private void ResumeNotifications()
+    {
+        if (_notificationSuppressionCount == 0)
+            throw new InvalidOperationException("Notifications are not currently suspended.");
+
+        _notificationSuppressionCount--;
+
+        if (_notificationSuppressionCount > 0)
+            return;
+
+        if (!_currentChangedDuringSuppression)
+            return;
+
+        _currentChangedDuringSuppression = false;
+        OnPropertyChanged(nameof(Current));
+    }
+
+    private sealed class NotificationSuspension(DuplicateExplorerSelectionContext owner) : IDisposable
+    {
+        private DuplicateExplorerSelectionContext? _owner = owner;
+
+        public void Dispose()
+        {
+            var owner = _owner;
+            if (owner is null)
+                return;
+
+            _owner = null;
+            owner.ResumeNotifications();
+        }
     }
 
     public readonly record struct SelectionTarget(
         SelectionKind Kind,
-        DirId? DirId,
         FileId? FileId,
-        DirId? ParentDirId)
+        ImmutableArray<DirId> DirectoryChain)
     {
-        public static SelectionTarget ForDirectory(DirId dirId, DirId? parentDirId = null)
-            => new(SelectionKind.Directory, dirId, null, parentDirId);
+        public DirId? ContextDirectoryId =>
+            DirectoryChain.Length > 0 ? DirectoryChain[^1] : null;
 
-        public static SelectionTarget ForFile(FileId fileId, DirId? parentDirId)
-            => new(SelectionKind.File, null, fileId, parentDirId);
+        public DirId? ParentOfContextDirectoryId =>
+            DirectoryChain.Length >= 2 ? DirectoryChain[^2] : null;
 
-        public static SelectionTarget ForSyntheticDirectoryBucket(DirId parentDirId)
-            => new(SelectionKind.SyntheticDirectoryBucket, null, null, parentDirId);
+        public static SelectionTarget ForDirectory(ImmutableArray<DirId> directoryChain) =>
+            new(SelectionKind.Directory, null, directoryChain);
+
+        public static SelectionTarget ForFile(FileId fileId, ImmutableArray<DirId> directoryChain) =>
+            new(SelectionKind.File, fileId, directoryChain);
+
+        public static SelectionTarget ForSyntheticDirectoryBucket(ImmutableArray<DirId> directoryChain) =>
+            new(SelectionKind.SyntheticDirectoryBucket, null, directoryChain);
     }
 
     public enum SelectionKind

--- a/DuplicateFileFinder.Gui/Features/Duplicates/Application/DuplicateExplorerSelectionContext.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/Application/DuplicateExplorerSelectionContext.cs
@@ -1,0 +1,48 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DuplicateFileFinder.Gui.Features.Duplicates.Application;
+
+public sealed class DuplicateExplorerSelectionContext : ObservableObject
+{
+    private SelectionTarget? _current;
+
+    public SelectionTarget? Current
+    {
+        get => _current;
+        set => SetCurrent(value);
+    }
+
+    public void SetCurrent(SelectionTarget? value, bool forceNotify = false)
+    {
+        if (!forceNotify && Nullable.Equals(_current, value))
+            return;
+
+        _current = value;
+
+        OnPropertyChanged(nameof(Current));
+    }
+
+    public readonly record struct SelectionTarget(
+        SelectionKind Kind,
+        DirId? DirId,
+        FileId? FileId,
+        DirId? ParentDirId)
+    {
+        public static SelectionTarget ForDirectory(DirId dirId, DirId? parentDirId = null)
+            => new(SelectionKind.Directory, dirId, null, parentDirId);
+
+        public static SelectionTarget ForFile(FileId fileId, DirId? parentDirId)
+            => new(SelectionKind.File, null, fileId, parentDirId);
+
+        public static SelectionTarget ForSyntheticDirectoryBucket(DirId parentDirId)
+            => new(SelectionKind.SyntheticDirectoryBucket, null, null, parentDirId);
+    }
+
+    public enum SelectionKind
+    {
+        None = 0,
+        Directory = 1,
+        File = 2,
+        SyntheticDirectoryBucket = 3
+    }
+}

--- a/DuplicateFileFinder.Gui/Features/Duplicates/Application/DuplicateSelectionTranslator.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/Application/DuplicateSelectionTranslator.cs
@@ -1,8 +1,11 @@
+using System.Collections.Immutable;
+
 using DuplicateFileFinder.Gui.Controls.TreeMap;
 using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.ScanRootsTree;
 using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.TreeMap;
 
 using DuplicateFileFinderLib.Repository.Core.Models;
+using DuplicateFileFinderLib.Repository.Plugins.Interfaces;
 
 namespace DuplicateFileFinder.Gui.Features.Duplicates.Application;
 
@@ -10,19 +13,21 @@ public static class DuplicateSelectionTranslator
 {
     public static DuplicateExplorerSelectionContext.SelectionTarget? FromTreeRow(
         RepoSnapshotView snapshot,
+        IFileDirReadModel fileDirIndex,
         ScanRootsRowViewModel? row)
     {
         if (row?.Dir is not { IsValid: true } dirHandle)
             return null;
 
-        var rec = snapshot.GetDirRecord(dirHandle);
-        var parentDirId = rec.ParentDirId >= 0 ? (DirId?)rec.ParentDirId : null;
-
-        return DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(rec.DirId, parentDirId);
+        var chain = BuildDirectoryChain(snapshot, fileDirIndex, dirHandle);
+        return chain.Length == 0
+            ? null
+            : DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(chain);
     }
 
     public static DuplicateExplorerSelectionContext.SelectionTarget? FromTreeMapNode(
         RepoSnapshotView snapshot,
+        IFileDirReadModel fileDirIndex,
         TreeMapNode<ITreeMapNodeElement>? node)
     {
         if (node?.Element is null)
@@ -31,42 +36,62 @@ public static class DuplicateSelectionTranslator
         switch (node.Element)
         {
             case DirTreeMapElement dirElement:
-                {
-                    var rec = snapshot.GetDirRecord(dirElement.Dir);
-                    var parentDirId = rec.ParentDirId >= 0 ? (DirId?)rec.ParentDirId : null;
-                    return DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(rec.DirId, parentDirId);
-                }
+            {
+                var chain = BuildDirectoryChain(snapshot, fileDirIndex, dirElement.Dir);
+                return chain.Length == 0
+                    ? null
+                    : DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(chain);
+            }
 
             case FileTreeMapElement fileElement:
-                {
-                    var rec = snapshot.GetFileRecord(fileElement.File);
-                    var parentDirId = rec.DirId >= 0 ? (DirId?)rec.DirId : null;
-                    return DuplicateExplorerSelectionContext.SelectionTarget.ForFile(rec.FileId, parentDirId);
-                }
+            {
+                var fileRec = snapshot.GetFileRecord(fileElement.File);
+
+                if (!fileDirIndex.TryGetDir(fileRec.DirId, out var parentDirHandle))
+                    return null;
+
+                var chain = BuildDirectoryChain(snapshot, fileDirIndex, parentDirHandle);
+                return chain.Length == 0
+                    ? null
+                    : DuplicateExplorerSelectionContext.SelectionTarget.ForFile(fileRec.FileId, chain);
+            }
 
             case SyntheticTreeMapElement { ParentDir: { } parentDir }:
-                {
-                    var rec = snapshot.GetDirRecord(parentDir);
-                    return DuplicateExplorerSelectionContext.SelectionTarget.ForSyntheticDirectoryBucket(rec.DirId);
-                }
+            {
+                var chain = BuildDirectoryChain(snapshot, fileDirIndex, parentDir);
+                return chain.Length == 0
+                    ? null
+                    : DuplicateExplorerSelectionContext.SelectionTarget.ForSyntheticDirectoryBucket(chain);
+            }
 
             default:
                 return null;
         }
     }
 
-    public static DirId? GetDesiredTreeDirectory(
-        DuplicateExplorerSelectionContext.SelectionTarget? target)
-    {
-        if (target is null)
-            return null;
 
-        return target.Value.Kind switch
+
+    private static ImmutableArray<DirId> BuildDirectoryChain(
+        RepoSnapshotView snapshot,
+        IFileDirReadModel fileDirIndex,
+        DirHandle dirHandle)
+    {
+        var builder = ImmutableArray.CreateBuilder<DirId>();
+        var current = dirHandle;
+
+        while (current.IsValid)
         {
-            DuplicateExplorerSelectionContext.SelectionKind.Directory => target.Value.DirId,
-            DuplicateExplorerSelectionContext.SelectionKind.File => target.Value.ParentDirId,
-            DuplicateExplorerSelectionContext.SelectionKind.SyntheticDirectoryBucket => target.Value.ParentDirId,
-            _ => null
-        };
+            var rec = snapshot.GetDirRecord(current);
+            builder.Add(rec.DirId);
+
+            if (rec.ParentDirId < 0)
+                break;
+
+            if (!fileDirIndex.TryGetDir(rec.ParentDirId, out current))
+                break;
+        }
+
+        builder.Reverse();
+        return builder.ToImmutable();
     }
 }

--- a/DuplicateFileFinder.Gui/Features/Duplicates/Application/DuplicateSelectionTranslator.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/Application/DuplicateSelectionTranslator.cs
@@ -1,0 +1,72 @@
+using DuplicateFileFinder.Gui.Controls.TreeMap;
+using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.ScanRootsTree;
+using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.TreeMap;
+
+using DuplicateFileFinderLib.Repository.Core.Models;
+
+namespace DuplicateFileFinder.Gui.Features.Duplicates.Application;
+
+public static class DuplicateSelectionTranslator
+{
+    public static DuplicateExplorerSelectionContext.SelectionTarget? FromTreeRow(
+        RepoSnapshotView snapshot,
+        ScanRootsRowViewModel? row)
+    {
+        if (row?.Dir is not { IsValid: true } dirHandle)
+            return null;
+
+        var rec = snapshot.GetDirRecord(dirHandle);
+        var parentDirId = rec.ParentDirId >= 0 ? (DirId?)rec.ParentDirId : null;
+
+        return DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(rec.DirId, parentDirId);
+    }
+
+    public static DuplicateExplorerSelectionContext.SelectionTarget? FromTreeMapNode(
+        RepoSnapshotView snapshot,
+        TreeMapNode<ITreeMapNodeElement>? node)
+    {
+        if (node?.Element is null)
+            return null;
+
+        switch (node.Element)
+        {
+            case DirTreeMapElement dirElement:
+                {
+                    var rec = snapshot.GetDirRecord(dirElement.Dir);
+                    var parentDirId = rec.ParentDirId >= 0 ? (DirId?)rec.ParentDirId : null;
+                    return DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(rec.DirId, parentDirId);
+                }
+
+            case FileTreeMapElement fileElement:
+                {
+                    var rec = snapshot.GetFileRecord(fileElement.File);
+                    var parentDirId = rec.DirId >= 0 ? (DirId?)rec.DirId : null;
+                    return DuplicateExplorerSelectionContext.SelectionTarget.ForFile(rec.FileId, parentDirId);
+                }
+
+            case SyntheticTreeMapElement { ParentDir: { } parentDir }:
+                {
+                    var rec = snapshot.GetDirRecord(parentDir);
+                    return DuplicateExplorerSelectionContext.SelectionTarget.ForSyntheticDirectoryBucket(rec.DirId);
+                }
+
+            default:
+                return null;
+        }
+    }
+
+    public static DirId? GetDesiredTreeDirectory(
+        DuplicateExplorerSelectionContext.SelectionTarget? target)
+    {
+        if (target is null)
+            return null;
+
+        return target.Value.Kind switch
+        {
+            DuplicateExplorerSelectionContext.SelectionKind.Directory => target.Value.DirId,
+            DuplicateExplorerSelectionContext.SelectionKind.File => target.Value.ParentDirId,
+            DuplicateExplorerSelectionContext.SelectionKind.SyntheticDirectoryBucket => target.Value.ParentDirId,
+            _ => null
+        };
+    }
+}

--- a/DuplicateFileFinder.Gui/Features/Duplicates/Application/DuplicateSelectionTranslator.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/Application/DuplicateSelectionTranslator.cs
@@ -36,33 +36,33 @@ public static class DuplicateSelectionTranslator
         switch (node.Element)
         {
             case DirTreeMapElement dirElement:
-            {
-                var chain = BuildDirectoryChain(snapshot, fileDirIndex, dirElement.Dir);
-                return chain.Length == 0
-                    ? null
-                    : DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(chain);
-            }
+                {
+                    var chain = BuildDirectoryChain(snapshot, fileDirIndex, dirElement.Dir);
+                    return chain.Length == 0
+                        ? null
+                        : DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(chain);
+                }
 
             case FileTreeMapElement fileElement:
-            {
-                var fileRec = snapshot.GetFileRecord(fileElement.File);
+                {
+                    var fileRec = snapshot.GetFileRecord(fileElement.File);
 
-                if (!fileDirIndex.TryGetDir(fileRec.DirId, out var parentDirHandle))
-                    return null;
+                    if (!fileDirIndex.TryGetDir(fileRec.DirId, out var parentDirHandle))
+                        return null;
 
-                var chain = BuildDirectoryChain(snapshot, fileDirIndex, parentDirHandle);
-                return chain.Length == 0
-                    ? null
-                    : DuplicateExplorerSelectionContext.SelectionTarget.ForFile(fileRec.FileId, chain);
-            }
+                    var chain = BuildDirectoryChain(snapshot, fileDirIndex, parentDirHandle);
+                    return chain.Length == 0
+                        ? null
+                        : DuplicateExplorerSelectionContext.SelectionTarget.ForFile(fileRec.FileId, chain);
+                }
 
             case SyntheticTreeMapElement { ParentDir: { } parentDir }:
-            {
-                var chain = BuildDirectoryChain(snapshot, fileDirIndex, parentDir);
-                return chain.Length == 0
-                    ? null
-                    : DuplicateExplorerSelectionContext.SelectionTarget.ForSyntheticDirectoryBucket(chain);
-            }
+                {
+                    var chain = BuildDirectoryChain(snapshot, fileDirIndex, parentDir);
+                    return chain.Length == 0
+                        ? null
+                        : DuplicateExplorerSelectionContext.SelectionTarget.ForSyntheticDirectoryBucket(chain);
+                }
 
             default:
                 return null;

--- a/DuplicateFileFinder.Gui/Features/Duplicates/Application/ScanRootsTree/ScanRootsTreeBuilder.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/Application/ScanRootsTree/ScanRootsTreeBuilder.cs
@@ -96,9 +96,6 @@ public sealed class ScanRootsTreeBuilder(IRepoHost host)
         return roots;
     }
 
-    public bool TryGetNode(DirHandle dirHandle, out ScanRootsTreeNode node)
-        => _nodesByDirHandle.TryGetValue(dirHandle, out node!);
-
     public bool TryGetDirHandle(DirId dirId, out DirHandle handle)
         => MainIndex.TryGetDir(dirId, out handle);
 
@@ -115,6 +112,21 @@ public sealed class ScanRootsTreeBuilder(IRepoHost host)
             return false;
 
         return true;
+    }
+
+    public bool TryGetParentDirHandle(DirHandle dirHandle, out DirHandle parentDirHandle)
+    {
+        parentDirHandle = DirHandle.Invalid;
+
+        if (_snapshot is null)
+            return false;
+
+        var dirRec = _snapshot.GetDirRecord(dirHandle);
+
+        if (dirRec.ParentDirId < 0)
+            return false;
+
+        return MainIndex.TryGetDir(dirRec.ParentDirId, out parentDirHandle);
     }
 
     public bool TryBuildAncestorChainToScanRoot(DirHandle target, out List<DirHandle> chainRootToTarget)

--- a/DuplicateFileFinder.Gui/Features/Duplicates/Application/SharedSelectionBinder.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/Application/SharedSelectionBinder.cs
@@ -1,0 +1,50 @@
+namespace DuplicateFileFinder.Gui.Features.Duplicates.Application;
+
+public sealed class SharedSelectionBinder<TLocalSelection>(
+    DuplicateExplorerSelectionContext selectionContext,
+    Func<TLocalSelection?> getLocalSelection,
+    Func<TLocalSelection?, DuplicateExplorerSelectionContext.SelectionTarget?> toSharedSelection,
+    Action<DuplicateExplorerSelectionContext.SelectionTarget?> applySharedSelection)
+{
+    private readonly DuplicateExplorerSelectionContext _selectionContext =
+        selectionContext ?? throw new ArgumentNullException(nameof(selectionContext));
+
+    private readonly Func<TLocalSelection?> _getLocalSelection =
+        getLocalSelection ?? throw new ArgumentNullException(nameof(getLocalSelection));
+
+    private readonly Func<TLocalSelection?, DuplicateExplorerSelectionContext.SelectionTarget?> _toSharedSelection =
+        toSharedSelection ?? throw new ArgumentNullException(nameof(toSharedSelection));
+
+    private readonly Action<DuplicateExplorerSelectionContext.SelectionTarget?> _applySharedSelection =
+        applySharedSelection ?? throw new ArgumentNullException(nameof(applySharedSelection));
+
+    private bool _syncing;
+
+    public void PublishFromLocal()
+    {
+        if (_syncing)
+            return;
+
+        var next = _toSharedSelection(_getLocalSelection());
+        if (Nullable.Equals(_selectionContext.Current, next))
+            return;
+
+        _selectionContext.SetCurrent(next);
+    }
+
+    public void ApplyFromShared()
+    {
+        if (_syncing)
+            return;
+
+        _syncing = true;
+        try
+        {
+            _applySharedSelection(_selectionContext.Current);
+        }
+        finally
+        {
+            _syncing = false;
+        }
+    }
+}

--- a/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/DuplicatesViewModel.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/DuplicatesViewModel.cs
@@ -1,22 +1,28 @@
+using System.ComponentModel;
+
 using CommunityToolkit.Mvvm.ComponentModel;
 
-using DuplicateFileFinder.Gui.Controls.TreeMap;
+using DuplicateFileFinder.Gui.Features.Duplicates.Application;
 using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.DuplicateGroups;
 using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.ScanRootsTree;
 using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.TreeMap;
+using DuplicateFileFinder.Gui.Infrastructure.Util;
 
 using DuplicateFileFinderLib.Logging;
 using DuplicateFileFinderLib.Repository.Core.Models;
 using DuplicateFileFinderLib.Repository.Interfaces;
-// ReSharper disable PartialTypeWithSinglePart
+using DuplicateFileFinderLib.Repository.Plugins.Interfaces;
 
 namespace DuplicateFileFinder.Gui.Features.Duplicates.ViewModels;
 
-public partial class DuplicatesViewModel : ObservableObject
+public class DuplicatesViewModel : ObservableObject
 {
     private readonly IRepo _repo;
+    private readonly IFileDirReadModel _fileDirIndex;
+    private readonly DuplicateExplorerSelectionContext _selectionContext;
 
-    private bool _syncingSelection;
+    // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
+    private readonly DisposableManager _disposer;
 
     public ScanRootsTreeViewModel ScanRootsTree { get; }
     public TreeMapActionsViewModel TreeMapActions { get; }
@@ -27,129 +33,31 @@ public partial class DuplicatesViewModel : ObservableObject
         ScanRootsTreeViewModel scanRootsTree,
         TreeMapController treeMapController,
         TreeMapActionsViewModel treeMapActions,
-        DuplicateGroupsViewModel duplicateGroups)
+        DuplicateGroupsViewModel duplicateGroups,
+        DuplicateExplorerSelectionContext selectionContext,
+        DisposableManager disposer)
     {
         ArgumentNullException.ThrowIfNull(host);
 
         _repo = host.Repo;
+        _fileDirIndex = host.FileDirIndex;
+        _selectionContext = selectionContext ?? throw new ArgumentNullException(nameof(selectionContext));
+        _disposer = disposer ?? throw new ArgumentNullException(nameof(disposer));
 
         ScanRootsTree = scanRootsTree ?? throw new ArgumentNullException(nameof(scanRootsTree));
         TreeMapController = treeMapController ?? throw new ArgumentNullException(nameof(treeMapController));
         TreeMapActions = treeMapActions ?? throw new ArgumentNullException(nameof(treeMapActions));
         DuplicateGroups = duplicateGroups ?? throw new ArgumentNullException(nameof(duplicateGroups));
 
-        // treemap selection drives navigation
-        TreeMapController.PropertyChanged += (_, e) =>
+        PropertyChangedEventHandler selectionHandler = (_, e) =>
         {
-            if (e.PropertyName == nameof(TreeMapController.SelectedNode))
-                OnTreeMapSelectionChanged();
+            if (e.PropertyName == nameof(DuplicateExplorerSelectionContext.Current))
+                SyncDuplicateGroupsFilterFromSelection();
         };
-
-        // scan-roots selection drives treemap sync + duplicates subtree filter
-        ScanRootsTree.PropertyChanged += (_, e) =>
-        {
-            if (e.PropertyName != nameof(ScanRootsTree.SelectedRow)) return;
-            OnScanRootsTreeSelectionChanged();
-            OnScanRootsTreeSelectionChanged_DuplicatesFilter();
-        };
+        _selectionContext.PropertyChanged += selectionHandler;
+        _disposer.Add(() => _selectionContext.PropertyChanged -= selectionHandler);
 
         LoadFromRepo();
-    }
-
-    private void OnScanRootsTreeSelectionChanged_DuplicatesFilter()
-    {
-        var row = ScanRootsTree.SelectedRow;
-
-        if (row?.Dir is { IsValid: true } dir)
-            DuplicateGroups.SelectedSubtreeDir = dir;
-        else
-            DuplicateGroups.SelectedSubtreeDir = null;
-    }
-
-    private void OnScanRootsTreeSelectionChanged()
-    {
-        if (_syncingSelection)
-            return;
-
-        var row = ScanRootsTree.SelectedRow;
-        if (row is null)
-        {
-            _syncingSelection = true;
-            try { TreeMapController.SelectedNode = null; }
-            finally { _syncingSelection = false; }
-            return;
-        }
-
-        // Nearest-ancestor fallback:
-        // try the selected row; if it isn't present in the treemap (depth cap, metric pruning, etc),
-        // walk up parents until we find something that exists.
-        var model = row.Model;
-        TreeMapNode<ITreeMapNodeElement>? target = null;
-
-        while (model is not null)
-        {
-            var dir = model.Dir;
-            if (dir.IsValid && TreeMapController.DirNodeByHandle.TryGetValue(dir, out var node))
-            {
-                target = node;
-                break;
-            }
-
-            model = model.Parent;
-        }
-
-        _syncingSelection = true;
-        try
-        {
-            // Prefer setting on UI thread to keep property-changed ordering consistent with view updates
-            Avalonia.Threading.Dispatcher.UIThread.Post(
-                () => TreeMapController.SelectedNode = target, // may be null if nothing found
-                Avalonia.Threading.DispatcherPriority.Background);
-        }
-        finally
-        {
-            _syncingSelection = false;
-        }
-    }
-
-    private void OnTreeMapSelectionChanged()
-    {
-        if (_syncingSelection)
-            return;
-
-        var node = TreeMapController.SelectedNode;
-        if (node?.Element == null)
-            return;
-
-        _syncingSelection = true;
-        try
-        {
-            if (node.Element is DirTreeMapElement dirNode)
-            {
-                var dir = dirNode.Dir;
-                Avalonia.Threading.Dispatcher.UIThread.Post(
-                    () => ScanRootsTree.NavigateToDir(dir),
-                    Avalonia.Threading.DispatcherPriority.Background);
-            }
-            else if (node.Element is FileTreeMapElement fileNode)
-            {
-                var file = fileNode.File;
-                Avalonia.Threading.Dispatcher.UIThread.Post(
-                    () => ScanRootsTree.NavigateToFile(file),
-                    Avalonia.Threading.DispatcherPriority.Background);
-            }
-            else if (node.Element is SyntheticTreeMapElement { ParentDir: not null } otherNode)
-            {
-                var dir = otherNode.ParentDir.Value;
-                Avalonia.Threading.Dispatcher.UIThread.Post(
-                    () => ScanRootsTree.NavigateToDir(dir),
-                    Avalonia.Threading.DispatcherPriority.Background);
-            }
-        }
-        finally
-        {
-            _syncingSelection = false;
-        }
     }
 
     // Expose treemap controller for binding
@@ -228,6 +136,8 @@ public partial class DuplicatesViewModel : ObservableObject
 
     private void InitializeFromSnapshot(RepoSnapshotView snapshot)
     {
+        var capturedSelection = _selectionContext.Current;
+
         ScanRootsTree.Rebuild(snapshot);
 
         DuplicateGroups.Rebuild(snapshot);
@@ -236,5 +146,95 @@ public partial class DuplicatesViewModel : ObservableObject
         {
             TreeMapController.Rebuild(snapshot);
         }
+
+        var restoredSelection = ResolveSelectionTarget(snapshot, capturedSelection);
+        _selectionContext.SetCurrent(restoredSelection, forceNotify: true);
+    }
+
+    private void SyncDuplicateGroupsFilterFromSelection()
+    {
+        var dirId = DuplicateSelectionTranslator.GetDesiredTreeDirectory(_selectionContext.Current);
+
+        DirHandle? subtree = null;
+        if (dirId is { } existingDirId && _fileDirIndex.TryGetDir(existingDirId, out var handle))
+            subtree = handle;
+
+        DuplicateGroups.SelectedSubtreeDir = subtree;
+    }
+
+    private DuplicateExplorerSelectionContext.SelectionTarget? ResolveSelectionTarget(
+        RepoSnapshotView snapshot,
+        DuplicateExplorerSelectionContext.SelectionTarget? captured)
+    {
+        if (captured is null)
+            return null;
+
+        if (captured.Value.Kind == DuplicateExplorerSelectionContext.SelectionKind.File
+            && captured.Value.FileId is { } fileId
+            && _fileDirIndex.TryGetFile(fileId, out _))
+        {
+            return captured;
+        }
+
+        DirId? desiredDirId = captured.Value.Kind switch
+        {
+            DuplicateExplorerSelectionContext.SelectionKind.Directory => captured.Value.DirId,
+            DuplicateExplorerSelectionContext.SelectionKind.File => captured.Value.ParentDirId,
+            DuplicateExplorerSelectionContext.SelectionKind.SyntheticDirectoryBucket => captured.Value.ParentDirId,
+            _ => null
+        };
+
+        if (desiredDirId is not { } dirId)
+            return null;
+
+        if (!TryResolveExistingOrAncestorDirId(snapshot, dirId, out var resolvedDirId))
+            return null;
+
+        DirId? parentDirId = TryGetParentDirId(snapshot, resolvedDirId, out var parent)
+            ? parent
+            : null;
+
+        return DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(resolvedDirId, parentDirId);
+    }
+
+    private bool TryResolveExistingOrAncestorDirId(
+        RepoSnapshotView snapshot,
+        DirId preferredDirId,
+        out DirId resolvedDirId)
+    {
+        var current = preferredDirId;
+
+        while (current >= 0)
+        {
+            if (_fileDirIndex.TryGetDir(current, out _))
+            {
+                resolvedDirId = current;
+                return true;
+            }
+
+            if (!TryGetParentDirId(snapshot, current, out current))
+                break;
+        }
+
+        resolvedDirId = -1;
+        return false;
+    }
+
+    private bool TryGetParentDirId(
+        RepoSnapshotView snapshot,
+        DirId dirId,
+        out DirId parentDirId)
+    {
+        parentDirId = -1;
+
+        if (!_fileDirIndex.TryGetDir(dirId, out var handle))
+            return false;
+
+        var rec = snapshot.GetDirRecord(handle);
+        if (rec.ParentDirId < 0)
+            return false;
+
+        parentDirId = rec.ParentDirId;
+        return true;
     }
 }

--- a/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/DuplicatesViewModel.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/DuplicatesViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.ComponentModel;
 
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -138,103 +139,80 @@ public class DuplicatesViewModel : ObservableObject
     {
         var capturedSelection = _selectionContext.Current;
 
-        ScanRootsTree.Rebuild(snapshot);
-
-        DuplicateGroups.Rebuild(snapshot);
-
-        using (TimingLog.StartPhase("BuildDirectoryTreeMap()"))
+        using (_selectionContext.SuspendNotifications())
         {
-            TreeMapController.Rebuild(snapshot);
-        }
+            ScanRootsTree.Rebuild(snapshot);
+            DuplicateGroups.Rebuild(snapshot);
 
-        var restoredSelection = ResolveSelectionTarget(snapshot, capturedSelection);
-        _selectionContext.SetCurrent(restoredSelection, forceNotify: true);
+            using (TimingLog.StartPhase("BuildDirectoryTreeMap()"))
+            {
+                TreeMapController.Rebuild(snapshot);
+            }
+
+            var restoredSelection = ResolveSelectionTarget(capturedSelection);
+            _selectionContext.Current = restoredSelection;
+        }
     }
 
     private void SyncDuplicateGroupsFilterFromSelection()
     {
-        var dirId = DuplicateSelectionTranslator.GetDesiredTreeDirectory(_selectionContext.Current);
-
         DirHandle? subtree = null;
-        if (dirId is { } existingDirId && _fileDirIndex.TryGetDir(existingDirId, out var handle))
+
+        if (_selectionContext.Current?.ContextDirectoryId is { } dirId
+            && _fileDirIndex.TryGetDir(dirId, out var handle))
+        {
             subtree = handle;
+        }
 
         DuplicateGroups.SelectedSubtreeDir = subtree;
     }
 
     private DuplicateExplorerSelectionContext.SelectionTarget? ResolveSelectionTarget(
-        RepoSnapshotView snapshot,
         DuplicateExplorerSelectionContext.SelectionTarget? captured)
     {
         if (captured is null)
             return null;
 
-        if (captured.Value.Kind == DuplicateExplorerSelectionContext.SelectionKind.File
-            && captured.Value.FileId is { } fileId
-            && _fileDirIndex.TryGetFile(fileId, out _))
+        return captured.Value.Kind switch
         {
-            return captured;
-        }
+            DuplicateExplorerSelectionContext.SelectionKind.Directory =>
+                ResolveDirectoryLikeSelection(captured.Value.DirectoryChain),
 
-        DirId? desiredDirId = captured.Value.Kind switch
-        {
-            DuplicateExplorerSelectionContext.SelectionKind.Directory => captured.Value.DirId,
-            DuplicateExplorerSelectionContext.SelectionKind.File => captured.Value.ParentDirId,
-            DuplicateExplorerSelectionContext.SelectionKind.SyntheticDirectoryBucket => captured.Value.ParentDirId,
+            DuplicateExplorerSelectionContext.SelectionKind.File =>
+                ResolveFileSelection(captured.Value),
+
+            DuplicateExplorerSelectionContext.SelectionKind.SyntheticDirectoryBucket =>
+                ResolveDirectoryLikeSelection(captured.Value.DirectoryChain),
+
             _ => null
         };
-
-        if (desiredDirId is not { } dirId)
-            return null;
-
-        if (!TryResolveExistingOrAncestorDirId(snapshot, dirId, out var resolvedDirId))
-            return null;
-
-        DirId? parentDirId = TryGetParentDirId(snapshot, resolvedDirId, out var parent)
-            ? parent
-            : null;
-
-        return DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(resolvedDirId, parentDirId);
     }
 
-    private bool TryResolveExistingOrAncestorDirId(
-        RepoSnapshotView snapshot,
-        DirId preferredDirId,
-        out DirId resolvedDirId)
+    private DuplicateExplorerSelectionContext.SelectionTarget? ResolveFileSelection(
+        DuplicateExplorerSelectionContext.SelectionTarget captured)
     {
-        var current = preferredDirId;
+        if (captured.FileId is { } fileId && _fileDirIndex.TryGetFile(fileId, out _))
+            return captured;
 
-        while (current >= 0)
+        return ResolveDirectoryLikeSelection(captured.DirectoryChain);
+    }
+
+    private DuplicateExplorerSelectionContext.SelectionTarget? ResolveDirectoryLikeSelection(
+        ImmutableArray<DirId> capturedChain)
+    {
+        if (capturedChain.IsDefaultOrEmpty)
+            return null;
+
+        for (var i = capturedChain.Length - 1; i >= 0; i--)
         {
-            if (_fileDirIndex.TryGetDir(current, out _))
-            {
-                resolvedDirId = current;
-                return true;
-            }
+            var candidateDirId = capturedChain[i];
+            if (!_fileDirIndex.TryGetDir(candidateDirId, out _))
+                continue;
 
-            if (!TryGetParentDirId(snapshot, current, out current))
-                break;
+            var survivingChain = capturedChain.Take(i + 1).ToImmutableArray();
+            return DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(survivingChain);
         }
 
-        resolvedDirId = -1;
-        return false;
-    }
-
-    private bool TryGetParentDirId(
-        RepoSnapshotView snapshot,
-        DirId dirId,
-        out DirId parentDirId)
-    {
-        parentDirId = -1;
-
-        if (!_fileDirIndex.TryGetDir(dirId, out var handle))
-            return false;
-
-        var rec = snapshot.GetDirRecord(handle);
-        if (rec.ParentDirId < 0)
-            return false;
-
-        parentDirId = rec.ParentDirId;
-        return true;
+        return null;
     }
 }

--- a/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/ScanRootsTree/ScanRootsTreeViewModel.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/ScanRootsTree/ScanRootsTreeViewModel.cs
@@ -12,6 +12,8 @@ using DuplicateFileFinder.Gui.Infrastructure.Util;
 
 using DuplicateFileFinderLib.Repository.Core.Models;
 using DuplicateFileFinderLib.Repository.Core.RepoEventing;
+using DuplicateFileFinderLib.Repository.Interfaces;
+using DuplicateFileFinderLib.Repository.Plugins.Interfaces;
 
 // ReSharper disable UnusedParameterInPartialMethod
 
@@ -24,6 +26,7 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
     private readonly IScanRootsTreeNodeActions _actions;
     private readonly IDeletionWorkflowService _deletionService;
     private readonly ScanRootsTreeBuilder _builder;
+
     // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
     private readonly SharedSelectionBinder<ScanRootsRowViewModel> _selectionBinder;
 
@@ -31,24 +34,25 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
     private readonly Dictionary<long, int> _rootIndexByScanRootId = new();
 
     // Remember expanded handles so Resort/Rebuild can restore expansion state
-    private readonly HashSet<DirHandle> _expanded = new();
+    private readonly HashSet<DirHandle> _expanded = [];
 
     // Handle->row for quick selection
     private readonly Dictionary<DirHandle, ScanRootsRowViewModel> _rowByHandle = new();
 
     private readonly DuplicateExplorerSelectionContext _selectionContext;
 
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(SelectedPath))]
+    [ObservableProperty] [NotifyPropertyChangedFor(nameof(SelectedPath))]
     private ScanRootsRowViewModel? _selectedRow;
 
     private RepoSnapshotView? _snapshot;
+    private readonly IFileDirReadModel _fileDirIndex;
 
     [ObservableProperty] private ScanRootsSortColumn _sortColumn = ScanRootsSortColumn.Size;
 
     [ObservableProperty] private bool _sortDescending = true;
 
     public ScanRootsTreeViewModel(
+        IRepoHost host,
         RepoUiEventRelayPlugin repoEvents,
         ScanRootsTreeBuilder builder,
         IScanRootsTreeNodeActions actions,
@@ -56,11 +60,14 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
         DisposableManager disposer,
         DuplicateExplorerSelectionContext selectionContext)
     {
+        ArgumentNullException.ThrowIfNull(host);
+
         _builder = builder ?? throw new ArgumentNullException(nameof(builder));
         _actions = actions ?? throw new ArgumentNullException(nameof(actions));
         _deletionService = deletionService ?? throw new ArgumentNullException(nameof(deletionService));
         _disposer = disposer ?? throw new ArgumentNullException(nameof(disposer));
         _selectionContext = selectionContext ?? throw new ArgumentNullException(nameof(selectionContext));
+        _fileDirIndex = host.FileDirIndex;
 
         _selectionBinder = new SharedSelectionBinder<ScanRootsRowViewModel>(
             _selectionContext,
@@ -148,7 +155,7 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
                 Rows.Add(CreateRow(model, 0));
 
             ApplyRootSort();
-            RebuildRootIndexMap_NoLock();
+            RebuildRootIndexMap();
         }
         finally
         {
@@ -156,7 +163,7 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
         }
     }
 
-    private void RebuildRootIndexMap_NoLock()
+    private void RebuildRootIndexMap()
     {
         _rootIndexByScanRootId.Clear();
 
@@ -269,7 +276,7 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
                 Rows.Insert(idx++, CreateRow(child, childDepth));
 
             var inserted = ordered.Count;
-            AdjustRootIndicesAfterMutation_NoLock(startIndexInclusive: insertAt + 1, delta: inserted);
+            AdjustRootIndicesAfterMutation(startIndexInclusive: insertAt + 1, delta: inserted);
         }
         finally
         {
@@ -310,7 +317,7 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
             }
 
             if (removed > 0)
-                AdjustRootIndicesAfterMutation_NoLock(startIndexInclusive: start + 1, delta: -removed);
+                AdjustRootIndicesAfterMutation(startIndexInclusive: start + 1, delta: -removed);
         }
         finally
         {
@@ -320,145 +327,30 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
 
     // ---- Navigation API
 
-    // public void NavigateToDir(DirHandle dirHandle) => NavigateToDirHandleLazyFast(dirHandle);
-    public void NavigateToDir(DirHandle dirHandle) => NavigateToDirHandleLazyFull(dirHandle);
+    public void NavigateToDir(DirHandle dirHandle)
+    {
+        var row = TryEnsureVisibleRow(dirHandle);
+        if (row is not null)
+            SelectRowAndCenter(row);
+    }
 
     public void NavigateToFile(FileHandle fileHandle)
     {
-        // if (_builder.TryGetParentDirHandle(fileHandle, out var parent))
-        //     NavigateToDirHandleLazyFast(parent);
         if (_builder.TryGetParentDirHandle(fileHandle, out var parent))
-            NavigateToDirHandleLazyFull(parent);
-    }
-
-    // This expands the path using full child creation, which materializes all siblings.
-    private void NavigateToDirHandleLazyFull(DirHandle target)
-    {
-        if (_snapshot is null)
-            return;
-
-        if (!_builder.TryBuildAncestorChainToScanRoot(target, out var chain))
-            return;
-
-        // Find root row
-        if (!_rowByHandle.TryGetValue(chain[0], out var current))
-            return;
-
-        // Expand path with full sibling enumeration
-        for (var i = 1; i < chain.Count; i++)
-        {
-            var parentRow = current;
-            var parentIndex = Rows.IndexOf(parentRow);
-            if (parentIndex < 0)
-                return;
-
-            if (!parentRow.IsExpanded)
-                Expand(parentRow);
-
-            var childHandle = chain[i];
-
-            if (!_rowByHandle.TryGetValue(childHandle, out current))
-                return;
-        }
-
-        SelectRowAndCenter(current);
-    }
-
-    // This only expands the path using fast child creation, without loading all siblings
-    // ReSharper disable once UnusedMember.Local
-    private void NavigateToDirHandleLazyFast(DirHandle target)
-    {
-        if (_snapshot is null)
-            return;
-
-        if (!_builder.TryBuildAncestorChainToScanRoot(target, out var chain))
-            return;
-
-        // Find root row
-        if (!_rowByHandle.TryGetValue(chain[0], out var current))
-            return;
-
-        // Expand path using FAST child creation (no sibling enumeration)
-        for (var i = 1; i < chain.Count; i++)
-        {
-            var parentRow = current;
-            var parentIndex = Rows.IndexOf(parentRow);
-            if (parentIndex < 0)
-                return;
-
-            var childHandle = chain[i];
-
-            // Ensure parent is marked expanded (for UI glyph/state)
-            parentRow.IsExpanded = true;
-            _expanded.Add(parentRow.Dir);
-
-            // If the child row already exists in the visible rows at the expected depth, use it.
-            if (_rowByHandle.TryGetValue(childHandle, out var existing))
-            {
-                current = existing;
-                continue;
-            }
-
-            // Ensure child MODEL without materializing siblings (critical).
-            if (!_builder.TryEnsureChildNodeFast(parentRow.Model, childHandle, out var childModel))
-                return;
-
-            // Insert child row directly under the parent if the subtree isn't already visible.
-            // If the next row is already a descendant, we don't insert here (avoid duplicates).
-            var nextIndex = parentIndex + 1;
-            if (nextIndex < Rows.Count && Rows[nextIndex].Depth > parentRow.Depth)
-                // subtree already present; try find the child in the visible range
-                current = FindInVisibleSubtree(parentRow, childHandle) ??
-                          CreateAndInsertSingleChild(parentRow, childModel);
-            else
-                current = CreateAndInsertSingleChild(parentRow, childModel);
-        }
-
-        SelectRowAndCenter(current);
-    }
-
-    private ScanRootsRowViewModel CreateAndInsertSingleChild(ScanRootsRowViewModel parentRow,
-        ScanRootsTreeNode childModel)
-    {
-        var parentIndex = Rows.IndexOf(parentRow);
-        var row = CreateRow(childModel, parentRow.Depth + 1);
-
-        Rows.Insert(parentIndex + 1, row);
-        return row;
-    }
-
-    private ScanRootsRowViewModel? FindInVisibleSubtree(ScanRootsRowViewModel parent, DirHandle wanted)
-    {
-        var start = Rows.IndexOf(parent);
-        if (start < 0)
-            return null;
-
-        var parentDepth = parent.Depth;
-        for (var i = start + 1; i < Rows.Count && Rows[i].Depth > parentDepth; i++)
-            if (Rows[i].Dir.Equals(wanted))
-                return Rows[i];
-
-        return null;
+            NavigateToDir(parent);
     }
 
     // ---- Ordering ----
 
     private List<ScanRootsTreeNode> OrderModels(List<ScanRootsTreeNode> models)
     {
-        var cmp = GetComparison();
-
         var list = models.ToList();
-        list.Sort((a, b) => cmp(Project(a), Project(b)));
+        list.Sort(GetModelComparison());
 
         if (SortDescending)
             list.Reverse();
 
         return list;
-
-        ScanRootsRowViewModel Project(ScanRootsTreeNode m)
-        {
-            return new ScanRootsRowViewModel(m, null, null, 0);
-        }
     }
 
     private void ApplyRootSort()
@@ -488,6 +380,7 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
         }
     }
 
+
     private void ResortVisible()
     {
         // Minimal-pain approach:
@@ -500,6 +393,20 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
         BuildFromRoots();
         RestoreExpandedState(toRestoreExpanded);
         ApplySelectionTarget(_selectionContext.Current);
+    }
+
+    private Comparison<ScanRootsTreeNode> GetModelComparison()
+    {
+        return SortColumn switch
+        {
+            ScanRootsSortColumn.Name => static (a, b) => StringComparer.OrdinalIgnoreCase.Compare(a.Name, b.Name),
+            ScanRootsSortColumn.Size => static (a, b) => a.TotalBytes.CompareTo(b.TotalBytes),
+            ScanRootsSortColumn.Items => static (a, b) => a.ItemCount.CompareTo(b.ItemCount),
+            ScanRootsSortColumn.Files => static (a, b) => a.FileCount.CompareTo(b.FileCount),
+            ScanRootsSortColumn.DupFiles => static (a, b) => a.DuplicateFiles.CompareTo(b.DuplicateFiles),
+            ScanRootsSortColumn.DupBytes => static (a, b) => a.DuplicateBytes.CompareTo(b.DuplicateBytes),
+            _ => static (_, _) => 0
+        };
     }
 
     private Comparison<ScanRootsRowViewModel> GetComparison()
@@ -518,67 +425,36 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
 
     private void RemoveScanRootFromRows(long scanRootId)
     {
-        if (!_rootIndexByScanRootId.TryGetValue(scanRootId, out var rootIndex))
-            return; // already removed / not visible
+        if (!TryGetValidatedRootIndex(scanRootId, out var rootIndex))
+            return;
 
-        if (rootIndex < 0 || rootIndex >= Rows.Count)
-        {
-            // Map got stale somehow; fall back to a quick rebuild of the map and retry once.
-            RebuildRootIndexMap_NoLock();
-            if (!_rootIndexByScanRootId.TryGetValue(scanRootId, out rootIndex))
-                return;
-            if (rootIndex < 0 || rootIndex >= Rows.Count)
-                return;
-        }
+        var endExclusive = rootIndex + 1;
+        while (endExclusive < Rows.Count && Rows[endExclusive].Depth > 0)
+            endExclusive++;
 
-        // Verify root at index (defensive)
-        var rootRow = Rows[rootIndex];
-        if (rootRow.Depth != 0 || rootRow.ScanRootId != scanRootId)
-        {
-            // Map stale due to unusual reorder; rebuild and retry once
-            RebuildRootIndexMap_NoLock();
-            if (!_rootIndexByScanRootId.TryGetValue(scanRootId, out rootIndex))
-                return;
+        var rowsToRemove = endExclusive - rootIndex;
+        if (rowsToRemove <= 0)
+            return;
 
-            rootRow = Rows[rootIndex];
-            if (rootRow.Depth != 0 || rootRow.ScanRootId != scanRootId)
-                return;
-        }
-
-        // If selection is inside subtree, clear it
-        if (SelectedRow is not null && SelectedRow.ScanRootId == scanRootId)
-            SelectedRow = null;
+        ClearSelectionIfInsideRemovedRoot(rootIndex, rowsToRemove);
 
         Rows.BeginUpdate();
         try
         {
-            // Remove contiguous visible range: root + its descendants until next root (depth 0) or end.
-            var removeAt = rootIndex;
-            var removedCount = 0;
-
-            while (removeAt < Rows.Count)
+            for (var i = 0; i < rowsToRemove; i++)
             {
-                if (removedCount > 0 && Rows[removeAt].Depth == 0)
-                    break; // next root => stop
-
-                var row = Rows[removeAt];
-
-                // Clear caches for real handles
+                var row = Rows[rootIndex];
                 if (row.Dir.IsValid)
                 {
                     _expanded.Remove(row.Dir);
                     _rowByHandle.Remove(row.Dir);
                 }
 
-                Rows.RemoveAt(removeAt);
-                removedCount++;
+                Rows.RemoveAt(rootIndex);
             }
 
-            // Remove root entry from root-index map
             _rootIndexByScanRootId.Remove(scanRootId);
-
-            // Adjust cached root indices for roots after the removed region
-            AdjustRootIndicesAfterMutation_NoLock(startIndexInclusive: rootIndex, delta: -removedCount);
+            AdjustRootIndicesAfterMutation(rootIndex, -rowsToRemove);
         }
         finally
         {
@@ -586,13 +462,8 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
         }
     }
 
-    private void AdjustRootIndicesAfterMutation_NoLock(int startIndexInclusive, int delta)
+    private void AdjustRootIndicesAfterMutation(int startIndexInclusive, int delta)
     {
-        if (delta == 0 || _rootIndexByScanRootId.Count == 0)
-            return;
-
-        // Only roots whose index is >= startIndexInclusive are affected
-        // (root rows can be anywhere due to expansions above them).
         var keys = _rootIndexByScanRootId.Keys.ToArray();
         foreach (var key in keys)
         {
@@ -600,6 +471,31 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
             if (idx >= startIndexInclusive)
                 _rootIndexByScanRootId[key] = idx + delta;
         }
+    }
+
+    private bool TryGetValidatedRootIndex(long scanRootId, out int rootIndex)
+    {
+        if (!_rootIndexByScanRootId.TryGetValue(scanRootId, out rootIndex))
+            return false;
+
+        if (rootIndex >= 0 && rootIndex < Rows.Count)
+            return true;
+
+        RebuildRootIndexMap();
+
+        return _rootIndexByScanRootId.TryGetValue(scanRootId, out rootIndex)
+               && rootIndex >= 0
+               && rootIndex < Rows.Count;
+    }
+
+    private void ClearSelectionIfInsideRemovedRoot(int rootIndex, int rowsToRemove)
+    {
+        if (SelectedRow is null)
+            return;
+
+        var selectedIndex = Rows.IndexOf(SelectedRow);
+        if (selectedIndex >= rootIndex && selectedIndex < rootIndex + rowsToRemove)
+            SelectedRow = null;
     }
 
     // ----------------------------
@@ -612,7 +508,7 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
         if (_snapshot is null)
             return null;
 
-        return DuplicateSelectionTranslator.FromTreeRow(_snapshot, row);
+        return DuplicateSelectionTranslator.FromTreeRow(_snapshot, _fileDirIndex, row);
     }
 
     private bool TryResolveExistingOrAncestorHandle(DirHandle preferred, out DirHandle resolved)
@@ -639,7 +535,7 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
         DuplicateExplorerSelectionContext.SelectionTarget? target,
         bool centerAfterSelect = false)
     {
-        var handle = ResolveHandleFromSharedSelection(target);
+        var handle = ResolveHandleFromSelectionTarget(target);
         if (handle is not { IsValid: true } dirHandle)
         {
             SelectedRow = null;
@@ -664,14 +560,13 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
             RequestCenterSelectedRow?.Invoke();
     }
 
-    private DirHandle? ResolveHandleFromSharedSelection(
+    private DirHandle? ResolveHandleFromSelectionTarget(
         DuplicateExplorerSelectionContext.SelectionTarget? target)
     {
         if (_snapshot is null)
             return null;
 
-        var dirId = DuplicateSelectionTranslator.GetDesiredTreeDirectory(target);
-        if (dirId is not { } desiredDirId)
+        if (target?.ContextDirectoryId is not { } desiredDirId)
             return null;
 
         return _builder.TryGetDirHandle(desiredDirId, out var handle)
@@ -725,27 +620,32 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
         }
     }
 
-    private bool EnsureVisible(DirHandle handle)
-    {
-        if (_rowByHandle.ContainsKey(handle))
-            return true;
+    private bool EnsureVisible(DirHandle handle) => TryEnsureVisibleRow(handle) is not null;
 
-        if (!_builder.TryBuildAncestorChainToScanRoot(handle, out var chain) || chain.Count == 0)
-            return false;
+    private ScanRootsRowViewModel? TryEnsureVisibleRow(DirHandle target)
+    {
+        if (_snapshot is null)
+            return null;
+
+        if (_rowByHandle.TryGetValue(target, out var existing))
+            return existing;
+
+        if (!_builder.TryBuildAncestorChainToScanRoot(target, out var chain) || chain.Count == 0)
+            return null;
 
         if (!_rowByHandle.TryGetValue(chain[0], out var current))
-            return false;
+            return null;
 
         for (var i = 1; i < chain.Count; i++)
         {
-            if (current is { IsExpanded: false, HasLazyChildren: true })
+            if (!current.IsExpanded)
                 Expand(current);
 
             if (!_rowByHandle.TryGetValue(chain[i], out current))
-                return false;
+                return null;
         }
 
-        return true;
+        return current;
     }
 
     // ------------------------------

--- a/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/ScanRootsTree/ScanRootsTreeViewModel.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/ScanRootsTree/ScanRootsTreeViewModel.cs
@@ -41,7 +41,8 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
 
     private readonly DuplicateExplorerSelectionContext _selectionContext;
 
-    [ObservableProperty] [NotifyPropertyChangedFor(nameof(SelectedPath))]
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SelectedPath))]
     private ScanRootsRowViewModel? _selectedRow;
 
     private RepoSnapshotView? _snapshot;

--- a/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/ScanRootsTree/ScanRootsTreeViewModel.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/ScanRootsTree/ScanRootsTreeViewModel.cs
@@ -1,9 +1,11 @@
+using System.ComponentModel;
 using System.Windows.Input;
 
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 using DuplicateFileFinder.Gui.Application.Deletion;
+using DuplicateFileFinder.Gui.Features.Duplicates.Application;
 using DuplicateFileFinder.Gui.Features.Duplicates.Application.ScanRootsTree;
 using DuplicateFileFinder.Gui.Infrastructure.Services;
 using DuplicateFileFinder.Gui.Infrastructure.Util;
@@ -22,6 +24,8 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
     private readonly IScanRootsTreeNodeActions _actions;
     private readonly IDeletionWorkflowService _deletionService;
     private readonly ScanRootsTreeBuilder _builder;
+    // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
+    private readonly SharedSelectionBinder<ScanRootsRowViewModel> _selectionBinder;
 
     // ScanRootId -> index in Rows where the depth-0 root row currently lives
     private readonly Dictionary<long, int> _rootIndexByScanRootId = new();
@@ -31,6 +35,8 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
 
     // Handle->row for quick selection
     private readonly Dictionary<DirHandle, ScanRootsRowViewModel> _rowByHandle = new();
+
+    private readonly DuplicateExplorerSelectionContext _selectionContext;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(SelectedPath))]
@@ -47,24 +53,48 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
         ScanRootsTreeBuilder builder,
         IScanRootsTreeNodeActions actions,
         IDeletionWorkflowService deletionService,
-        DisposableManager disposer)
+        DisposableManager disposer,
+        DuplicateExplorerSelectionContext selectionContext)
     {
         _builder = builder ?? throw new ArgumentNullException(nameof(builder));
         _actions = actions ?? throw new ArgumentNullException(nameof(actions));
         _deletionService = deletionService ?? throw new ArgumentNullException(nameof(deletionService));
         _disposer = disposer ?? throw new ArgumentNullException(nameof(disposer));
+        _selectionContext = selectionContext ?? throw new ArgumentNullException(nameof(selectionContext));
+
+        _selectionBinder = new SharedSelectionBinder<ScanRootsRowViewModel>(
+            _selectionContext,
+            getLocalSelection: () => SelectedRow,
+            toSharedSelection: CreateSelectionTargetFromRow,
+            applySharedSelection: target => ApplySelectionTarget(target, centerAfterSelect: true));
 
         SortByCommand = new RelayCommand<ScanRootsSortColumn>(SortBy);
         ToggleExpandedCommand = new RelayCommand<ScanRootsRowViewModel>(ToggleExpanded);
 
         repoEvents.ScanRootRemoved += ScanRootRemovedEventHandler;
         disposer.Add(() => repoEvents.ScanRootRemoved -= ScanRootRemovedEventHandler);
+
+        PropertyChangedEventHandler selfHandler = (_, e) =>
+        {
+            if (e.PropertyName == nameof(SelectedRow))
+                _selectionBinder.PublishFromLocal();
+        };
+
+        PropertyChangedEventHandler selectionHandler = (_, e) =>
+        {
+            if (e.PropertyName == nameof(DuplicateExplorerSelectionContext.Current))
+                _selectionBinder.ApplyFromShared();
+        };
+
+        PropertyChanged += selfHandler;
+        _selectionContext.PropertyChanged += selectionHandler;
+
+        _disposer.Add(() => PropertyChanged -= selfHandler);
+        _disposer.Add(() => _selectionContext.PropertyChanged -= selectionHandler);
     }
 
-    private void ScanRootRemovedEventHandler(object? sender, RepoScanRootRemovedEvent e)
-    {
+    private void ScanRootRemovedEventHandler(object? sender, RepoScanRootRemovedEvent e) =>
         RemoveScanRootFromRows(e.ScanRootIdValue);
-    }
 
     // Visible, virtualized rows
     public BulkObservableCollection<ScanRootsRowViewModel> Rows { get; } = [];
@@ -93,8 +123,11 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
     public void Rebuild(RepoSnapshotView snapshot)
     {
         _snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
-        _expanded.Clear();
+
+        var expandedToRestore = _expanded.ToArray();
+
         BuildFromRoots();
+        RestoreExpandedState(expandedToRestore);
     }
 
     private void BuildFromRoots()
@@ -462,13 +495,11 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
         if (_snapshot is null)
             return;
 
-        var toRestore = _expanded.ToArray();
+        var toRestoreExpanded = _expanded.ToArray();
 
         BuildFromRoots();
-
-        foreach (var h in toRestore)
-            if (_rowByHandle.TryGetValue(h, out var row) && row is { HasLazyChildren: true, IsExpanded: false })
-                Expand(row);
+        RestoreExpandedState(toRestoreExpanded);
+        ApplySelectionTarget(_selectionContext.Current);
     }
 
     private Comparison<ScanRootsRowViewModel> GetComparison()
@@ -571,6 +602,155 @@ public sealed partial class ScanRootsTreeViewModel : ObservableObject, IAsyncDis
         }
     }
 
+    // ----------------------------
+    // Selection synchronisation
+    // ----------------------------
+
+    private DuplicateExplorerSelectionContext.SelectionTarget? CreateSelectionTargetFromRow(
+        ScanRootsRowViewModel? row)
+    {
+        if (_snapshot is null)
+            return null;
+
+        return DuplicateSelectionTranslator.FromTreeRow(_snapshot, row);
+    }
+
+    private bool TryResolveExistingOrAncestorHandle(DirHandle preferred, out DirHandle resolved)
+    {
+        var current = preferred;
+
+        while (current.IsValid)
+        {
+            if (_rowByHandle.ContainsKey(current))
+            {
+                resolved = current;
+                return true;
+            }
+
+            if (!_builder.TryGetParentDirHandle(current, out current))
+                break;
+        }
+
+        resolved = DirHandle.Invalid;
+        return false;
+    }
+
+    private void ApplySelectionTarget(
+        DuplicateExplorerSelectionContext.SelectionTarget? target,
+        bool centerAfterSelect = false)
+    {
+        var handle = ResolveHandleFromSharedSelection(target);
+        if (handle is not { IsValid: true } dirHandle)
+        {
+            SelectedRow = null;
+            return;
+        }
+
+        if (!EnsureVisible(dirHandle))
+        {
+            if (!TryResolveExistingOrAncestorHandle(dirHandle, out var resolvedAncestor) ||
+                !EnsureVisible(resolvedAncestor))
+            {
+                SelectedRow = null;
+                return;
+            }
+
+            dirHandle = resolvedAncestor;
+        }
+
+        SelectedRow = _rowByHandle.GetValueOrDefault(dirHandle);
+
+        if (centerAfterSelect && SelectedRow is not null)
+            RequestCenterSelectedRow?.Invoke();
+    }
+
+    private DirHandle? ResolveHandleFromSharedSelection(
+        DuplicateExplorerSelectionContext.SelectionTarget? target)
+    {
+        if (_snapshot is null)
+            return null;
+
+        var dirId = DuplicateSelectionTranslator.GetDesiredTreeDirectory(target);
+        if (dirId is not { } desiredDirId)
+            return null;
+
+        return _builder.TryGetDirHandle(desiredDirId, out var handle)
+            ? handle
+            : null;
+    }
+
+    private void RestoreExpandedState(IEnumerable<DirHandle> expandedHandles)
+    {
+        _expanded.Clear();
+
+        if (_snapshot is null)
+            return;
+
+        var ordered = expandedHandles
+            .Select(h =>
+            {
+                var depth = _builder.TryBuildAncestorChainToScanRoot(h, out var chain)
+                    ? chain.Count
+                    : int.MaxValue;
+                return (Handle: h, Depth: depth);
+            })
+            .OrderBy(x => x.Depth)
+            .ToArray();
+
+        foreach (var item in ordered)
+        {
+            if (item.Depth == int.MaxValue)
+                continue;
+
+            if (!_builder.TryBuildAncestorChainToScanRoot(item.Handle, out var chain) || chain.Count == 0)
+                continue;
+
+            if (!_rowByHandle.TryGetValue(chain[0], out var current))
+                continue;
+
+            for (var i = 1; i < chain.Count; i++)
+            {
+                if (current is { IsExpanded: false, HasLazyChildren: true })
+                    Expand(current);
+
+                if (!_rowByHandle.TryGetValue(chain[i], out current))
+                {
+                    current = null!;
+                    break;
+                }
+            }
+
+            if (current is { HasLazyChildren: true, IsExpanded: false })
+                Expand(current);
+        }
+    }
+
+    private bool EnsureVisible(DirHandle handle)
+    {
+        if (_rowByHandle.ContainsKey(handle))
+            return true;
+
+        if (!_builder.TryBuildAncestorChainToScanRoot(handle, out var chain) || chain.Count == 0)
+            return false;
+
+        if (!_rowByHandle.TryGetValue(chain[0], out var current))
+            return false;
+
+        for (var i = 1; i < chain.Count; i++)
+        {
+            if (current is { IsExpanded: false, HasLazyChildren: true })
+                Expand(current);
+
+            if (!_rowByHandle.TryGetValue(chain[i], out current))
+                return false;
+        }
+
+        return true;
+    }
+
+    // ------------------------------
+    // Cleanup
+    // ------------------------------
     public ValueTask DisposeAsync()
     {
         _disposer.Dispose();

--- a/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/TreeMap/TreeMapController.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/TreeMap/TreeMapController.cs
@@ -212,7 +212,7 @@ public partial class TreeMapController : ObservableObject, IAsyncDisposable
         if (_lastSnapshot is null)
             return null;
 
-        return DuplicateSelectionTranslator.FromTreeMapNode(_lastSnapshot, node);
+        return DuplicateSelectionTranslator.FromTreeMapNode(_lastSnapshot, _fileDirIndex, node);
     }
 
     private void ApplySelectionTarget(DuplicateExplorerSelectionContext.SelectionTarget? target) =>
@@ -232,18 +232,13 @@ public partial class TreeMapController : ObservableObject, IAsyncDisposable
             return fileNode;
         }
 
-        DirId? desiredDirId = target.Value.Kind switch
+        if (target.Value.ContextDirectoryId is { } dirId
+            && TryResolveExistingOrAncestorDirNode(dirId, out var dirNode))
         {
-            DuplicateExplorerSelectionContext.SelectionKind.Directory => target.Value.DirId,
-            DuplicateExplorerSelectionContext.SelectionKind.File => target.Value.ParentDirId,
-            DuplicateExplorerSelectionContext.SelectionKind.SyntheticDirectoryBucket => target.Value.ParentDirId,
-            _ => null
-        };
+            return dirNode;
+        }
 
-        if (desiredDirId is not { } dirId)
-            return null;
-
-        return TryResolveExistingOrAncestorDirNode(dirId, out var dirNode) ? dirNode : null;
+        return null;
     }
 
     private bool TryResolveExistingOrAncestorDirNode(

--- a/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/TreeMap/TreeMapController.cs
+++ b/DuplicateFileFinder.Gui/Features/Duplicates/ViewModels/TreeMap/TreeMapController.cs
@@ -1,7 +1,11 @@
+using System.ComponentModel;
+
 using CommunityToolkit.Mvvm.ComponentModel;
 
 using DuplicateFileFinder.Gui.Controls.TreeMap;
+using DuplicateFileFinder.Gui.Features.Duplicates.Application;
 using DuplicateFileFinder.Gui.Features.Duplicates.Application.TreeMap;
+using DuplicateFileFinder.Gui.Infrastructure.Util;
 
 using DuplicateFileFinderLib.Repository.Core.Models;
 using DuplicateFileFinderLib.Repository.Interfaces;
@@ -9,11 +13,17 @@ using DuplicateFileFinderLib.Repository.Plugins.Interfaces;
 
 namespace DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.TreeMap;
 
-public partial class TreeMapController : ObservableObject
+public partial class TreeMapController : ObservableObject, IAsyncDisposable
 {
     private readonly IRepo _repo;
     private readonly ITreeIndexReadModel _treeIndex;
     private readonly IFileDirReadModel _fileDirIndex;
+    private readonly DisposableManager _disposer;
+
+    private readonly DuplicateExplorerSelectionContext _selectionContext;
+
+    // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
+    private readonly SharedSelectionBinder<TreeMapNode<ITreeMapNodeElement>> _selectionBinder;
 
     private RepoSnapshotView? _lastSnapshot;
 
@@ -29,13 +39,41 @@ public partial class TreeMapController : ObservableObject
 
     [ObservableProperty] private TreeMapNode<ITreeMapNodeElement>? _selectedNode;
 
-    public TreeMapController(IRepoHost host)
+    public TreeMapController(IRepoHost host,
+        DuplicateExplorerSelectionContext selectionContext,
+        DisposableManager disposer)
     {
         ArgumentNullException.ThrowIfNull(host);
+        _selectionContext = selectionContext ?? throw new ArgumentNullException(nameof(selectionContext));
+        _disposer = disposer ?? throw new ArgumentNullException(nameof(disposer));
 
         _repo = host.Repo ?? throw new ArgumentNullException(nameof(host));
         _treeIndex = host.TreeIndex;
         _fileDirIndex = host.FileDirIndex;
+
+        _selectionBinder = new SharedSelectionBinder<TreeMapNode<ITreeMapNodeElement>>(
+            _selectionContext,
+            getLocalSelection: () => SelectedNode,
+            toSharedSelection: CreateSelectionTargetFromNode,
+            applySharedSelection: ApplySelectionTarget);
+
+
+        PropertyChangedEventHandler selfHandler = (_, e) =>
+        {
+            if (e.PropertyName == nameof(SelectedNode))
+                _selectionBinder.PublishFromLocal();
+        };
+
+        PropertyChangedEventHandler selectionHandler = (_, e) =>
+        {
+            if (e.PropertyName == nameof(DuplicateExplorerSelectionContext.Current))
+                _selectionBinder.ApplyFromShared();
+        };
+        PropertyChanged += selfHandler;
+        _selectionContext.PropertyChanged += selectionHandler;
+
+        _disposer.Add(() => PropertyChanged -= selfHandler);
+        _disposer.Add(() => _selectionContext.PropertyChanged -= selectionHandler);
     }
 
     public TreeMapBuildOptions Options { get; init; } = TreeMapBuildOptions.Default;
@@ -106,7 +144,7 @@ public partial class TreeMapController : ObservableObject
             });
 
         RebuildLookups();
-        SelectedNode = null;
+        ApplySelectionTarget(_selectionContext.Current);
     }
 
     partial void OnMetricChanged(TreeMapMetric value)
@@ -128,7 +166,7 @@ public partial class TreeMapController : ObservableObject
             });
 
         RebuildLookups();
-        SelectedNode = null;
+        ApplySelectionTarget(_selectionContext.Current);
 
         OnPropertyChanged(nameof(IsMetricBytes));
         OnPropertyChanged(nameof(IsMetricFiles));
@@ -162,5 +200,99 @@ public partial class TreeMapController : ObservableObject
                     stack.Push(n.Children[i]);
             }
         }
+    }
+
+    // ------------------------------
+    // Selection synchronisation
+    // ------------------------------
+
+    private DuplicateExplorerSelectionContext.SelectionTarget? CreateSelectionTargetFromNode(
+        TreeMapNode<ITreeMapNodeElement>? node)
+    {
+        if (_lastSnapshot is null)
+            return null;
+
+        return DuplicateSelectionTranslator.FromTreeMapNode(_lastSnapshot, node);
+    }
+
+    private void ApplySelectionTarget(DuplicateExplorerSelectionContext.SelectionTarget? target) =>
+        SelectedNode = ResolveNodeFromSelectionTarget(target);
+
+    private TreeMapNode<ITreeMapNodeElement>? ResolveNodeFromSelectionTarget(
+        DuplicateExplorerSelectionContext.SelectionTarget? target)
+    {
+        if (target is null)
+            return null;
+
+        if (target.Value.Kind == DuplicateExplorerSelectionContext.SelectionKind.File
+            && target.Value.FileId is { } fileId
+            && _fileDirIndex.TryGetFile(fileId, out var fileHandle)
+            && _fileNodeByHandle.TryGetValue(fileHandle, out var fileNode))
+        {
+            return fileNode;
+        }
+
+        DirId? desiredDirId = target.Value.Kind switch
+        {
+            DuplicateExplorerSelectionContext.SelectionKind.Directory => target.Value.DirId,
+            DuplicateExplorerSelectionContext.SelectionKind.File => target.Value.ParentDirId,
+            DuplicateExplorerSelectionContext.SelectionKind.SyntheticDirectoryBucket => target.Value.ParentDirId,
+            _ => null
+        };
+
+        if (desiredDirId is not { } dirId)
+            return null;
+
+        return TryResolveExistingOrAncestorDirNode(dirId, out var dirNode) ? dirNode : null;
+    }
+
+    private bool TryResolveExistingOrAncestorDirNode(
+        DirId preferredDirId,
+        out TreeMapNode<ITreeMapNodeElement> node)
+    {
+        var current = preferredDirId;
+
+        while (current >= 0)
+        {
+            if (_fileDirIndex.TryGetDir(current, out var handle)
+                && _dirNodeByHandle.TryGetValue(handle, out var resolvedNode))
+            {
+                node = resolvedNode;
+                return true;
+            }
+
+            if (!TryGetParentDirId(current, out current))
+                break;
+        }
+
+        node = null!;
+        return false;
+    }
+
+    private bool TryGetParentDirId(DirId dirId, out DirId parentDirId)
+    {
+        parentDirId = -1;
+
+        if (_lastSnapshot is null)
+            return false;
+
+        if (!_fileDirIndex.TryGetDir(dirId, out var handle))
+            return false;
+
+        var rec = _lastSnapshot.GetDirRecord(handle);
+        if (rec.ParentDirId < 0)
+            return false;
+
+        parentDirId = rec.ParentDirId;
+        return true;
+    }
+
+    // ------------------------------
+    // Cleanup
+    // ------------------------------
+    public ValueTask DisposeAsync()
+    {
+        _disposer.Dispose();
+        return ValueTask.CompletedTask;
     }
 }

--- a/DuplicateFileFinder.Gui/Infrastructure/Bootstrapper/GuiBootStrapper.cs
+++ b/DuplicateFileFinder.Gui/Infrastructure/Bootstrapper/GuiBootStrapper.cs
@@ -1,4 +1,5 @@
 using DuplicateFileFinder.Gui.Application.Deletion;
+using DuplicateFileFinder.Gui.Features.Duplicates.Application;
 using DuplicateFileFinder.Gui.Features.Duplicates.Application.ScanRootsTree;
 using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels;
 using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.DuplicateGroups;
@@ -50,6 +51,7 @@ public static class GuiBootstrapper
 
         // Application
         services.AddSingleton<IDeletionWorkflowService, DeletionWorkflowService>();
+        services.AddSingleton<DuplicateExplorerSelectionContext>();
 
         // Duplicate groups
         services.AddSingleton<DuplicateGroupsViewModel>();
@@ -65,7 +67,9 @@ public static class GuiBootstrapper
         services.AddSingleton<TreeMapController>(sp =>
         {
             var h = sp.GetRequiredService<IRepoHost>();
-            var tm = new TreeMapController(h)
+            var selectionContext = sp.GetRequiredService<DuplicateExplorerSelectionContext>();
+            var disposer = sp.GetRequiredService<DisposableManager>();
+            var tm = new TreeMapController(h, selectionContext, disposer)
             {
                 Options = new TreeMapBuildOptions { MaxDepth = 8 }
             };

--- a/DuplicateFileFinder.GuiTests/Features/Duplicates/DuplicatesViewModelCrossViewSyncTests.cs
+++ b/DuplicateFileFinder.GuiTests/Features/Duplicates/DuplicatesViewModelCrossViewSyncTests.cs
@@ -195,7 +195,10 @@ public sealed class DuplicatesViewModelCrossViewSyncTests
             Metric = TreeMapMetric.TotalBytes,
             Options = new TreeMapBuildOptions
             {
-                MaxDepth = 8, MaxSubdirsPerDir = 64, MaxFilesPerDir = 64, MaxTotalFileNodes = 1024
+                MaxDepth = 8,
+                MaxSubdirsPerDir = 64,
+                MaxFilesPerDir = 64,
+                MaxTotalFileNodes = 1024
             }
         };
 

--- a/DuplicateFileFinder.GuiTests/Features/Duplicates/DuplicatesViewModelCrossViewSyncTests.cs
+++ b/DuplicateFileFinder.GuiTests/Features/Duplicates/DuplicatesViewModelCrossViewSyncTests.cs
@@ -1,0 +1,157 @@
+using DuplicateFileFinder.Gui.Application.Deletion;
+using DuplicateFileFinder.Gui.Features.Duplicates.Application;
+using DuplicateFileFinder.Gui.Features.Duplicates.Application.ScanRootsTree;
+using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels;
+using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.DuplicateGroups;
+using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.ScanRootsTree;
+using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.TreeMap;
+using DuplicateFileFinder.Gui.Infrastructure.Services;
+using DuplicateFileFinder.Gui.Infrastructure.Util;
+using DuplicateFileFinder.GuiTests.Features.Duplicates.TestSupport;
+using DuplicateFileFinder.GuiTests.UI.Fakes;
+
+using DuplicateFileFinderLib.Repository.Core.Models;
+using DuplicateFileFinderLib.Repository.Interfaces;
+
+using Moq;
+
+using Xunit;
+
+namespace DuplicateFileFinder.GuiTests.Features.Duplicates;
+
+public sealed class DuplicatesViewModelCrossViewSyncTests
+{
+    [Fact]
+    public void TreeNavigation_UpdatesTreeMapSelection_AndDuplicateGroupsFilter()
+    {
+        var snapshot = DuplicatesSelectionTestHelpers.BuildSnapshot(
+            scanRootId: 1,
+            dirs:
+            [
+                new(100, -1, "root"),
+                new(200, 100, "A"),
+                new(300, 200, "B")
+            ],
+            files:
+            [
+                new(700, 300, "f.txt", 123)
+            ]);
+
+        var env = CreateSut(snapshot);
+
+        Assert.True(DuplicatesSelectionTestHelpers.TryGetDirHandle(snapshot, 1, 300, out var dir300));
+
+        env.ViewModel.ScanRootsTree.NavigateToDir(dir300);
+
+        var current = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(env.SelectionContext.Current);
+        Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.Directory, current.Kind);
+        Assert.Equal(300, current.DirId);
+
+        Assert.NotNull(env.ViewModel.TreeMapController.SelectedNode);
+        var selectedDir = Assert.IsType<DirTreeMapElement>(env.ViewModel.TreeMapController.SelectedNode!.Element);
+        Assert.Equal(300, snapshot.GetDirRecord(selectedDir.Dir).DirId);
+
+        Assert.Equal(dir300, env.DuplicateGroups.SelectedSubtreeDir);
+    }
+
+    [Fact]
+    public void TreeMapFileSelection_UpdatesTreeSelection_AndDuplicateGroupsFilterToParentDirectory()
+    {
+        var snapshot = DuplicatesSelectionTestHelpers.BuildSnapshot(
+            scanRootId: 1,
+            dirs:
+            [
+                new(100, -1, "root"),
+                new(200, 100, "A")
+            ],
+            files:
+            [
+                new(700, 200, "f.txt", 123)
+            ]);
+
+        var env = CreateSut(snapshot);
+
+        var file700 = new FileHandle(1, 0);
+        env.ViewModel.TreeMapController.SelectedNode = env.ViewModel.TreeMapController.FileNodeByHandle[file700];
+
+
+        var current = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(env.SelectionContext.Current);
+        Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.File, current.Kind);
+        Assert.Equal(700, current.FileId);
+        Assert.Equal(200, current.ParentDirId);
+
+        Assert.NotNull(env.ViewModel.ScanRootsTree.SelectedRow);
+        Assert.Equal(200, snapshot.GetDirRecord(env.ViewModel.ScanRootsTree.SelectedRow!.Dir).DirId);
+
+        Assert.Equal(new DirHandle(1, 1), env.DuplicateGroups.SelectedSubtreeDir);
+    }
+
+    private static Sut CreateSut(RepoSnapshotView snapshot)
+    {
+        var repo = new FakeRepo(snapshot.ScanRoots.Values) { SnapshotToReturn = snapshot };
+        var fileDir = new FakeFileDirReadModel();
+        DuplicatesSelectionTestHelpers.SeedFileDir(fileDir, snapshot);
+
+        var treeIndex = DuplicatesSelectionTestHelpers.BuildTreeIndex(snapshot);
+        var hashIndex = DuplicatesSelectionTestHelpers.BuildEmptyHashIndex();
+
+        var host = new Mock<IRepoHost>(MockBehavior.Strict);
+        host.SetupGet(x => x.Repo).Returns(repo);
+        host.SetupGet(x => x.FileDirIndex).Returns(fileDir);
+        host.SetupGet(x => x.TreeIndex).Returns(treeIndex);
+        host.SetupGet(x => x.HashIndex).Returns(hashIndex);
+        host.SetupGet(x => x.LastIndexedGeneration).Returns(1);
+
+        var selectionContext = new DuplicateExplorerSelectionContext();
+
+        var treeVm = new ScanRootsTreeViewModel(
+            new RepoUiEventRelayPlugin(new AvaloniaUiDispatcher()),
+            new ScanRootsTreeBuilder(host.Object),
+            Mock.Of<IScanRootsTreeNodeActions>(),
+            Mock.Of<IDeletionWorkflowService>(),
+            new DisposableManager(),
+            selectionContext);
+
+        var treeMapVm = new TreeMapController(host.Object, selectionContext, new DisposableManager())
+        {
+            Metric = TreeMapMetric.TotalBytes,
+            Options = new TreeMapBuildOptions
+            {
+                MaxDepth = 8,
+                MaxSubdirsPerDir = 64,
+                MaxFilesPerDir = 64,
+                MaxTotalFileNodes = 1024
+            }
+        };
+
+        var duplicateGroupsController = new DuplicateGroupsController(host.Object);
+        var duplicateGroups = new DuplicateGroupsViewModel(
+            host.Object,
+            duplicateGroupsController,
+            Mock.Of<IDeletionWorkflowService>(),
+            Mock.Of<IClipboardService>());
+
+        var treeMapActions = new TreeMapActionsViewModel(
+            host.Object,
+            Mock.Of<IScanCoordinator>(),
+            Mock.Of<IDeletionWorkflowService>(),
+            Mock.Of<IClipboardService>(),
+            new DisposableManager());
+
+        var vm = new DuplicatesViewModel(
+            host.Object,
+            treeVm,
+            treeMapVm,
+            treeMapActions,
+            duplicateGroups,
+            selectionContext,
+            new DisposableManager());
+
+        return new Sut(vm, selectionContext, duplicateGroups);
+    }
+
+    private sealed record Sut(
+        DuplicatesViewModel ViewModel,
+        DuplicateExplorerSelectionContext SelectionContext,
+        DuplicateGroupsViewModel DuplicateGroups);
+}

--- a/DuplicateFileFinder.GuiTests/Features/Duplicates/DuplicatesViewModelCrossViewSyncTests.cs
+++ b/DuplicateFileFinder.GuiTests/Features/Duplicates/DuplicatesViewModelCrossViewSyncTests.cs
@@ -11,7 +11,6 @@ using DuplicateFileFinder.GuiTests.Features.Duplicates.TestSupport;
 using DuplicateFileFinder.GuiTests.UI.Fakes;
 
 using DuplicateFileFinderLib.Repository.Core.Models;
-using DuplicateFileFinderLib.Repository.Interfaces;
 
 using Moq;
 
@@ -45,7 +44,7 @@ public sealed class DuplicatesViewModelCrossViewSyncTests
 
         var current = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(env.SelectionContext.Current);
         Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.Directory, current.Kind);
-        Assert.Equal(300, current.DirId);
+        Assert.Equal(300, current.ContextDirectoryId);
 
         Assert.NotNull(env.ViewModel.TreeMapController.SelectedNode);
         var selectedDir = Assert.IsType<DirTreeMapElement>(env.ViewModel.TreeMapController.SelectedNode!.Element);
@@ -74,11 +73,10 @@ public sealed class DuplicatesViewModelCrossViewSyncTests
         var file700 = new FileHandle(1, 0);
         env.ViewModel.TreeMapController.SelectedNode = env.ViewModel.TreeMapController.FileNodeByHandle[file700];
 
-
         var current = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(env.SelectionContext.Current);
         Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.File, current.Kind);
         Assert.Equal(700, current.FileId);
-        Assert.Equal(200, current.ParentDirId);
+        Assert.Equal(200, current.ContextDirectoryId);
 
         Assert.NotNull(env.ViewModel.ScanRootsTree.SelectedRow);
         Assert.Equal(200, snapshot.GetDirRecord(env.ViewModel.ScanRootsTree.SelectedRow!.Dir).DirId);
@@ -86,60 +84,137 @@ public sealed class DuplicatesViewModelCrossViewSyncTests
         Assert.Equal(new DirHandle(1, 1), env.DuplicateGroups.SelectedSubtreeDir);
     }
 
+    [Fact]
+    public void LoadFromRepo_WhenSelectedDirectoryIsDeleted_PreReloadSelectionContainsDeletedDirAndParent()
+    {
+        var initialSnapshot = DuplicatesSelectionTestHelpers.BuildSnapshot(
+            scanRootId: 1,
+            dirs:
+            [
+                new(100, -1, "root"),
+                new(200, 100, "A"),
+                new(300, 200, "B")
+            ],
+            files:
+            [
+                new(700, 300, "f.txt", 123)
+            ]);
+
+        var env = CreateSut(initialSnapshot);
+
+        Assert.True(DuplicatesSelectionTestHelpers.TryGetDirHandle(initialSnapshot, 1, 300, out var dir300));
+        env.ViewModel.ScanRootsTree.NavigateToDir(dir300);
+
+        var before = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(env.SelectionContext.Current);
+        Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.Directory, before.Kind);
+        Assert.Equal(300, before.ContextDirectoryId);
+        Assert.Equal(200, before.ParentOfContextDirectoryId);
+    }
+
+    [Fact]
+    public void LoadFromRepo_WhenSelectedDirectoryIsDeleted_FallsBackToParentDirectory()
+    {
+        var initialSnapshot = DuplicatesSelectionTestHelpers.BuildSnapshot(
+            scanRootId: 1,
+            dirs:
+            [
+                new(100, -1, "root"),
+                new(200, 100, "A"),
+                new(300, 200, "B")
+            ],
+            files:
+            [
+                new(700, 300, "f.txt", 123)
+            ]);
+
+        var updatedSnapshot = DuplicatesSelectionTestHelpers.BuildSnapshot(
+            scanRootId: 1,
+            dirs:
+            [
+                new(100, -1, "root"),
+                new(200, 100, "A")
+            ],
+            files: []);
+
+        var env = CreateSut(initialSnapshot);
+
+        Assert.True(DuplicatesSelectionTestHelpers.TryGetDirHandle(initialSnapshot, 1, 300, out var dir300));
+        Assert.True(DuplicatesSelectionTestHelpers.TryGetDirHandle(updatedSnapshot, 1, 200, out var dir200));
+
+        env.ViewModel.ScanRootsTree.NavigateToDir(dir300);
+
+        var before = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(env.SelectionContext.Current);
+        Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.Directory, before.Kind);
+        Assert.Equal(300, before.ContextDirectoryId);
+        Assert.Equal(200, before.ParentOfContextDirectoryId);
+
+        env.Repo.SnapshotToReturn = updatedSnapshot;
+
+        DuplicatesSelectionTestHelpers.ResetAndSeedFileDir(env.FileDir, updatedSnapshot);
+        DuplicatesSelectionTestHelpers.ConfigureTreeIndex(env.TreeIndex, updatedSnapshot);
+
+        env.ViewModel.LoadFromRepo();
+
+        var after = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(env.SelectionContext.Current);
+        Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.Directory, after.Kind);
+        Assert.Equal(200, after.ContextDirectoryId);
+
+        Assert.NotNull(env.ViewModel.ScanRootsTree.SelectedRow);
+        Assert.Equal(200, updatedSnapshot.GetDirRecord(env.ViewModel.ScanRootsTree.SelectedRow!.Dir).DirId);
+
+        Assert.Equal(dir200, env.DuplicateGroups.SelectedSubtreeDir);
+    }
+
     private static Sut CreateSut(RepoSnapshotView snapshot)
     {
         var repo = new FakeRepo(snapshot.ScanRoots.Values) { SnapshotToReturn = snapshot };
+
         var fileDir = new FakeFileDirReadModel();
-        DuplicatesSelectionTestHelpers.SeedFileDir(fileDir, snapshot);
+        DuplicatesSelectionTestHelpers.ResetAndSeedFileDir(fileDir, snapshot);
 
-        var treeIndex = DuplicatesSelectionTestHelpers.BuildTreeIndex(snapshot);
-        var hashIndex = DuplicatesSelectionTestHelpers.BuildEmptyHashIndex();
+        var treeIndex = new FakeTreeIndex();
+        DuplicatesSelectionTestHelpers.ConfigureTreeIndex(treeIndex, snapshot);
 
-        var host = new Mock<IRepoHost>(MockBehavior.Strict);
-        host.SetupGet(x => x.Repo).Returns(repo);
-        host.SetupGet(x => x.FileDirIndex).Returns(fileDir);
-        host.SetupGet(x => x.TreeIndex).Returns(treeIndex);
-        host.SetupGet(x => x.HashIndex).Returns(hashIndex);
-        host.SetupGet(x => x.LastIndexedGeneration).Returns(1);
+        var hashIndex = new FakeHashIndex();
+
+        var host = new FakeRepoHost(repo) { FileDirIndex = fileDir, TreeIndex = treeIndex, HashIndex = hashIndex };
 
         var selectionContext = new DuplicateExplorerSelectionContext();
 
         var treeVm = new ScanRootsTreeViewModel(
+            host,
             new RepoUiEventRelayPlugin(new AvaloniaUiDispatcher()),
-            new ScanRootsTreeBuilder(host.Object),
+            new ScanRootsTreeBuilder(host),
             Mock.Of<IScanRootsTreeNodeActions>(),
             Mock.Of<IDeletionWorkflowService>(),
             new DisposableManager(),
             selectionContext);
 
-        var treeMapVm = new TreeMapController(host.Object, selectionContext, new DisposableManager())
+        var treeMapVm = new TreeMapController(host, selectionContext, new DisposableManager())
         {
             Metric = TreeMapMetric.TotalBytes,
             Options = new TreeMapBuildOptions
             {
-                MaxDepth = 8,
-                MaxSubdirsPerDir = 64,
-                MaxFilesPerDir = 64,
-                MaxTotalFileNodes = 1024
+                MaxDepth = 8, MaxSubdirsPerDir = 64, MaxFilesPerDir = 64, MaxTotalFileNodes = 1024
             }
         };
 
-        var duplicateGroupsController = new DuplicateGroupsController(host.Object);
+        var duplicateGroupsController = new DuplicateGroupsController(host);
         var duplicateGroups = new DuplicateGroupsViewModel(
-            host.Object,
+            host,
             duplicateGroupsController,
             Mock.Of<IDeletionWorkflowService>(),
             Mock.Of<IClipboardService>());
 
         var treeMapActions = new TreeMapActionsViewModel(
-            host.Object,
+            host,
             Mock.Of<IScanCoordinator>(),
             Mock.Of<IDeletionWorkflowService>(),
             Mock.Of<IClipboardService>(),
             new DisposableManager());
 
         var vm = new DuplicatesViewModel(
-            host.Object,
+            host,
             treeVm,
             treeMapVm,
             treeMapActions,
@@ -147,11 +222,14 @@ public sealed class DuplicatesViewModelCrossViewSyncTests
             selectionContext,
             new DisposableManager());
 
-        return new Sut(vm, selectionContext, duplicateGroups);
+        return new Sut(vm, selectionContext, duplicateGroups, repo, fileDir, treeIndex);
     }
 
     private sealed record Sut(
         DuplicatesViewModel ViewModel,
         DuplicateExplorerSelectionContext SelectionContext,
-        DuplicateGroupsViewModel DuplicateGroups);
+        DuplicateGroupsViewModel DuplicateGroups,
+        FakeRepo Repo,
+        FakeFileDirReadModel FileDir,
+        FakeTreeIndex TreeIndex);
 }

--- a/DuplicateFileFinder.GuiTests/Features/Duplicates/ScanRootsTree/ScanRootsTreeSelectionSyncTests.cs
+++ b/DuplicateFileFinder.GuiTests/Features/Duplicates/ScanRootsTree/ScanRootsTreeSelectionSyncTests.cs
@@ -7,8 +7,6 @@ using DuplicateFileFinder.Gui.Infrastructure.Util;
 using DuplicateFileFinder.GuiTests.Features.Duplicates.TestSupport;
 using DuplicateFileFinder.GuiTests.UI.Fakes;
 
-using DuplicateFileFinderLib.Repository.Interfaces;
-
 using Moq;
 
 using Xunit;
@@ -30,24 +28,30 @@ public sealed class ScanRootsTreeSelectionSyncTests
             ],
             files: []);
 
-        var repo = new FakeRepo(snapshot.ScanRoots.Values) { SnapshotToReturn = snapshot };
+        var repo = new FakeRepo(snapshot.ScanRoots.Values)
+        {
+            SnapshotToReturn = snapshot
+        };
+
         var fileDir = new FakeFileDirReadModel();
-        DuplicatesSelectionTestHelpers.SeedFileDir(fileDir, snapshot);
+        DuplicatesSelectionTestHelpers.ResetAndSeedFileDir(fileDir, snapshot);
 
-        var treeIndex = DuplicatesSelectionTestHelpers.BuildTreeIndex(snapshot);
+        var treeIndex = new FakeTreeIndex();
+        DuplicatesSelectionTestHelpers.ConfigureTreeIndex(treeIndex, snapshot);
 
-        var host = new Mock<IRepoHost>(MockBehavior.Strict);
-        host.SetupGet(x => x.Repo).Returns(repo);
-        host.SetupGet(x => x.FileDirIndex).Returns(fileDir);
-        host.SetupGet(x => x.TreeIndex).Returns(treeIndex);
-        host.SetupGet(x => x.HashIndex).Returns(DuplicatesSelectionTestHelpers.BuildEmptyHashIndex());
-        host.SetupGet(x => x.LastIndexedGeneration).Returns(1);
+        var host = new FakeRepoHost(repo)
+        {
+            FileDirIndex = fileDir,
+            TreeIndex = treeIndex,
+            HashIndex = new FakeHashIndex()
+        };
 
         var selectionContext = new DuplicateExplorerSelectionContext();
 
         var vm = new ScanRootsTreeViewModel(
+            host,
             new RepoUiEventRelayPlugin(new AvaloniaUiDispatcher()),
-            new ScanRootsTreeBuilder(host.Object),
+            new ScanRootsTreeBuilder(host),
             Mock.Of<IScanRootsTreeNodeActions>(),
             Mock.Of<IDeletionWorkflowService>(),
             new DisposableManager(),
@@ -61,8 +65,8 @@ public sealed class ScanRootsTreeSelectionSyncTests
 
         var current = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(selectionContext.Current);
         Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.Directory, current.Kind);
-        Assert.Equal(300, current.DirId);
-        Assert.Equal(200, current.ParentDirId);
+        Assert.Equal(300, current.ContextDirectoryId);
+        Assert.Equal(200, current.ParentOfContextDirectoryId);
 
         Assert.NotNull(vm.SelectedRow);
         Assert.Equal(300, snapshot.GetDirRecord(vm.SelectedRow!.Dir).DirId);
@@ -80,24 +84,30 @@ public sealed class ScanRootsTreeSelectionSyncTests
             ],
             files: []);
 
-        var repo = new FakeRepo(snapshot.ScanRoots.Values) { SnapshotToReturn = snapshot };
+        var repo = new FakeRepo(snapshot.ScanRoots.Values)
+        {
+            SnapshotToReturn = snapshot
+        };
+
         var fileDir = new FakeFileDirReadModel();
-        DuplicatesSelectionTestHelpers.SeedFileDir(fileDir, snapshot);
+        DuplicatesSelectionTestHelpers.ResetAndSeedFileDir(fileDir, snapshot);
 
-        var treeIndex = DuplicatesSelectionTestHelpers.BuildTreeIndex(snapshot);
+        var treeIndex = new FakeTreeIndex();
+        DuplicatesSelectionTestHelpers.ConfigureTreeIndex(treeIndex, snapshot);
 
-        var host = new Mock<IRepoHost>(MockBehavior.Strict);
-        host.SetupGet(x => x.Repo).Returns(repo);
-        host.SetupGet(x => x.FileDirIndex).Returns(fileDir);
-        host.SetupGet(x => x.TreeIndex).Returns(treeIndex);
-        host.SetupGet(x => x.HashIndex).Returns(DuplicatesSelectionTestHelpers.BuildEmptyHashIndex());
-        host.SetupGet(x => x.LastIndexedGeneration).Returns(1);
+        var host = new FakeRepoHost(repo)
+        {
+            FileDirIndex = fileDir,
+            TreeIndex = treeIndex,
+            HashIndex = new FakeHashIndex()
+        };
 
         var selectionContext = new DuplicateExplorerSelectionContext();
 
         var vm = new ScanRootsTreeViewModel(
+            host,
             new RepoUiEventRelayPlugin(new AvaloniaUiDispatcher()),
-            new ScanRootsTreeBuilder(host.Object),
+            new ScanRootsTreeBuilder(host),
             Mock.Of<IScanRootsTreeNodeActions>(),
             Mock.Of<IDeletionWorkflowService>(),
             new DisposableManager(),
@@ -108,7 +118,7 @@ public sealed class ScanRootsTreeSelectionSyncTests
         Assert.True(DuplicatesSelectionTestHelpers.TryGetDirHandle(snapshot, 1, 200, out var dir200));
 
         vm.NavigateToDir(dir200);
-        selectionContext.Current = DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(200, 100);
+        selectionContext.Current = DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory([100, 200]);
 
         Assert.NotNull(vm.SelectedRow);
         Assert.Equal(200, snapshot.GetDirRecord(vm.SelectedRow!.Dir).DirId);

--- a/DuplicateFileFinder.GuiTests/Features/Duplicates/ScanRootsTree/ScanRootsTreeSelectionSyncTests.cs
+++ b/DuplicateFileFinder.GuiTests/Features/Duplicates/ScanRootsTree/ScanRootsTreeSelectionSyncTests.cs
@@ -1,0 +1,116 @@
+using DuplicateFileFinder.Gui.Application.Deletion;
+using DuplicateFileFinder.Gui.Features.Duplicates.Application;
+using DuplicateFileFinder.Gui.Features.Duplicates.Application.ScanRootsTree;
+using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.ScanRootsTree;
+using DuplicateFileFinder.Gui.Infrastructure.Services;
+using DuplicateFileFinder.Gui.Infrastructure.Util;
+using DuplicateFileFinder.GuiTests.Features.Duplicates.TestSupport;
+using DuplicateFileFinder.GuiTests.UI.Fakes;
+
+using DuplicateFileFinderLib.Repository.Interfaces;
+
+using Moq;
+
+using Xunit;
+
+namespace DuplicateFileFinder.GuiTests.Features.Duplicates.ScanRootsTree;
+
+public sealed class ScanRootsTreeSelectionSyncTests
+{
+    [Fact]
+    public void NavigateToDir_PublishesDirectorySelectionToSharedContext()
+    {
+        var snapshot = DuplicatesSelectionTestHelpers.BuildSnapshot(
+            scanRootId: 1,
+            dirs:
+            [
+                new(100, -1, "root"),
+                new(200, 100, "A"),
+                new(300, 200, "B")
+            ],
+            files: []);
+
+        var repo = new FakeRepo(snapshot.ScanRoots.Values) { SnapshotToReturn = snapshot };
+        var fileDir = new FakeFileDirReadModel();
+        DuplicatesSelectionTestHelpers.SeedFileDir(fileDir, snapshot);
+
+        var treeIndex = DuplicatesSelectionTestHelpers.BuildTreeIndex(snapshot);
+
+        var host = new Mock<IRepoHost>(MockBehavior.Strict);
+        host.SetupGet(x => x.Repo).Returns(repo);
+        host.SetupGet(x => x.FileDirIndex).Returns(fileDir);
+        host.SetupGet(x => x.TreeIndex).Returns(treeIndex);
+        host.SetupGet(x => x.HashIndex).Returns(DuplicatesSelectionTestHelpers.BuildEmptyHashIndex());
+        host.SetupGet(x => x.LastIndexedGeneration).Returns(1);
+
+        var selectionContext = new DuplicateExplorerSelectionContext();
+
+        var vm = new ScanRootsTreeViewModel(
+            new RepoUiEventRelayPlugin(new AvaloniaUiDispatcher()),
+            new ScanRootsTreeBuilder(host.Object),
+            Mock.Of<IScanRootsTreeNodeActions>(),
+            Mock.Of<IDeletionWorkflowService>(),
+            new DisposableManager(),
+            selectionContext);
+
+        vm.Rebuild(snapshot);
+
+        Assert.True(DuplicatesSelectionTestHelpers.TryGetDirHandle(snapshot, 1, 300, out var dir300));
+
+        vm.NavigateToDir(dir300);
+
+        var current = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(selectionContext.Current);
+        Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.Directory, current.Kind);
+        Assert.Equal(300, current.DirId);
+        Assert.Equal(200, current.ParentDirId);
+
+        Assert.NotNull(vm.SelectedRow);
+        Assert.Equal(300, snapshot.GetDirRecord(vm.SelectedRow!.Dir).DirId);
+    }
+
+    [Fact]
+    public void SettingSharedDirectorySelection_SelectsMatchingVisibleTreeRow()
+    {
+        var snapshot = DuplicatesSelectionTestHelpers.BuildSnapshot(
+            scanRootId: 1,
+            dirs:
+            [
+                new(100, -1, "root"),
+                new(200, 100, "A")
+            ],
+            files: []);
+
+        var repo = new FakeRepo(snapshot.ScanRoots.Values) { SnapshotToReturn = snapshot };
+        var fileDir = new FakeFileDirReadModel();
+        DuplicatesSelectionTestHelpers.SeedFileDir(fileDir, snapshot);
+
+        var treeIndex = DuplicatesSelectionTestHelpers.BuildTreeIndex(snapshot);
+
+        var host = new Mock<IRepoHost>(MockBehavior.Strict);
+        host.SetupGet(x => x.Repo).Returns(repo);
+        host.SetupGet(x => x.FileDirIndex).Returns(fileDir);
+        host.SetupGet(x => x.TreeIndex).Returns(treeIndex);
+        host.SetupGet(x => x.HashIndex).Returns(DuplicatesSelectionTestHelpers.BuildEmptyHashIndex());
+        host.SetupGet(x => x.LastIndexedGeneration).Returns(1);
+
+        var selectionContext = new DuplicateExplorerSelectionContext();
+
+        var vm = new ScanRootsTreeViewModel(
+            new RepoUiEventRelayPlugin(new AvaloniaUiDispatcher()),
+            new ScanRootsTreeBuilder(host.Object),
+            Mock.Of<IScanRootsTreeNodeActions>(),
+            Mock.Of<IDeletionWorkflowService>(),
+            new DisposableManager(),
+            selectionContext);
+
+        vm.Rebuild(snapshot);
+
+        Assert.True(DuplicatesSelectionTestHelpers.TryGetDirHandle(snapshot, 1, 200, out var dir200));
+
+        vm.NavigateToDir(dir200);
+        selectionContext.Current = DuplicateExplorerSelectionContext.SelectionTarget.ForDirectory(200, 100);
+
+        Assert.NotNull(vm.SelectedRow);
+        Assert.Equal(200, snapshot.GetDirRecord(vm.SelectedRow!.Dir).DirId);
+    }
+}

--- a/DuplicateFileFinder.GuiTests/Features/Duplicates/TestSupport/DuplicatesSelectionTestHelpers.cs
+++ b/DuplicateFileFinder.GuiTests/Features/Duplicates/TestSupport/DuplicatesSelectionTestHelpers.cs
@@ -103,8 +103,16 @@ internal static class DuplicatesSelectionTestHelpers
         }
     }
 
-    internal static FakeTreeIndex BuildTreeIndex(RepoSnapshotView snapshot)
+    internal static void ResetAndSeedFileDir(FakeFileDirReadModel fileDir, RepoSnapshotView snapshot)
     {
+        fileDir.Reset();
+        SeedFileDir(fileDir, snapshot);
+    }
+
+    internal static void ConfigureTreeIndex(FakeTreeIndex treeIndex, RepoSnapshotView snapshot)
+    {
+        treeIndex.Reset();
+
         var childDirsByParent = new Dictionary<DirHandle, DirHandle[]>();
         var childFilesByParent = new Dictionary<DirHandle, FileHandle[]>();
         var statsByDir = new Dictionary<DirHandle, DirAggregateStats>();
@@ -147,56 +155,55 @@ internal static class DuplicatesSelectionTestHelpers
         foreach (var dir in childDirsByParent.Keys)
             statsByDir[dir] = ComputeStats(dir);
 
-        return new FakeTreeIndex()
-        {
-            GetChildDirsImpl = dir =>
-                childDirsByParent.TryGetValue(dir, out var children)
-                    ? children
-                    : ReadOnlySpan<DirHandle>.Empty,
-            GetChildFilesImpl = dir =>
-                childFilesByParent.TryGetValue(dir, out var files)
-                    ? files
-                    : ReadOnlySpan<FileHandle>.Empty,
-            GetDirStatsImpl = dir =>
-                statsByDir.TryGetValue(dir, out var stats)
-                    ? stats
-                    : new DirAggregateStats
-                    {
-                        TotalBytes = 0,
-                        FileCount = 0,
-                        DirCount = 0,
-                        DuplicateFiles = 0,
-                        DuplicateBytes = 0
-                    }
-        };
+        treeIndex.GetChildDirsImpl = dir =>
+            childDirsByParent.TryGetValue(dir, out var children)
+                ? children
+                : ReadOnlySpan<DirHandle>.Empty;
+
+        treeIndex.GetChildFilesImpl = dir =>
+            childFilesByParent.TryGetValue(dir, out var files)
+                ? files
+                : ReadOnlySpan<FileHandle>.Empty;
+
+        treeIndex.GetDirStatsImpl = dir =>
+            statsByDir.TryGetValue(dir, out var stats)
+                ? stats
+                : new DirAggregateStats
+                {
+                    TotalBytes = 0,
+                    FileCount = 0,
+                    DirCount = 0,
+                    DuplicateFiles = 0,
+                    DuplicateBytes = 0
+                };
 
         DirAggregateStats ComputeStats(DirHandle dir)
         {
             var childDirs = childDirsByParent.TryGetValue(dir, out var dirs) ? dirs : [];
             var childFiles = childFilesByParent.TryGetValue(dir, out var files) ? files : [];
 
-            var totalDirs = childDirs.Length;
-            var totalFiles = childFiles.Length;
-            long totalBytes = childFiles.Length * 100L;
+        var totalDirs = childDirs.Length;
+        var totalFiles = childFiles.Length;
+        long totalBytes = childFiles.Length == 0 ? 0 : childFiles.Length * 100L;
 
-            foreach (var child in childDirs)
-            {
-                var childStats = ComputeStats(child);
-                totalDirs += childStats.DirCount;
-                totalFiles += childStats.FileCount;
-                totalBytes += childStats.TotalBytes;
-            }
-
-            return new DirAggregateStats
-            {
-                DirCount = totalDirs,
-                FileCount = totalFiles,
-                TotalBytes = totalBytes,
-                DuplicateFiles = 0,
-                DuplicateBytes = 0
-            };
+        foreach (var child in childDirs)
+        {
+            var childStats = ComputeStats(child);
+            totalDirs += childStats.DirCount;
+            totalFiles += childStats.FileCount;
+            totalBytes += childStats.TotalBytes;
         }
+
+        return new DirAggregateStats
+        {
+            DirCount = totalDirs,
+            FileCount = totalFiles,
+            TotalBytes = totalBytes,
+            DuplicateFiles = 0,
+            DuplicateBytes = 0
+        };
     }
+}
 
     internal static bool TryGetDirHandle(
         RepoSnapshotView snapshot,

--- a/DuplicateFileFinder.GuiTests/Features/Duplicates/TestSupport/DuplicatesSelectionTestHelpers.cs
+++ b/DuplicateFileFinder.GuiTests/Features/Duplicates/TestSupport/DuplicatesSelectionTestHelpers.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using DuplicateFileFinder.GuiTests.UI.Fakes;
+
+using DuplicateFileFinderLib.Repository.Core.Models;
+using DuplicateFileFinderLib.Repository.Plugins.Interfaces;
+using DuplicateFileFinderLib.Repository.Plugins.Models;
+using DuplicateFileFinderLib.Repository.Storage;
+using DuplicateFileFinderLib.Repository.Storage.Models;
+
+namespace DuplicateFileFinder.GuiTests.Features.Duplicates.TestSupport;
+
+internal static class DuplicatesSelectionTestHelpers
+{
+    internal sealed record DirDef(DirId DirId, DirId ParentDirId, string Name);
+
+    internal sealed record FileDef(FileId FileId, DirId DirId, string Name, long Size);
+
+    internal static RepoSnapshotView BuildSnapshot(
+        ScanRootId scanRootId,
+        IReadOnlyList<DirDef> dirs,
+        IReadOnlyList<FileDef> files,
+        string rootPath = "/root")
+    {
+        var strings = new PackedStringBuilder();
+
+        var dirRecords = dirs
+            .Select(d => new DirRecordV2
+            {
+                DirId = d.DirId,
+                ParentDirId = d.ParentDirId,
+                NameStrIdx = strings.InternOrMinusOne(d.Name),
+                Status = ScanEntryStatus.Enumerated,
+                LastSeenScanSequence = 1,
+            })
+            .ToArray();
+
+        var fileRecords = files
+            .Select(f => new FileRecordV2
+            {
+                FileId = f.FileId,
+                DirId = f.DirId,
+                NameStrIdx = strings.InternOrMinusOne(f.Name),
+                Status = ScanEntryStatus.Enumerated,
+                LastSeenScanSequence = 1,
+                Size = f.Size,
+                Hash = new HashKey(1, 2)
+            })
+            .ToArray();
+
+        var rootSnapshot = new ScanRootSnapshotView
+        {
+            ScanRootId = scanRootId,
+            StringPool = strings.Build(),
+            Dirs = dirRecords,
+            Files = fileRecords
+        };
+
+        return new RepoSnapshotView
+        {
+            Snapshots = new Dictionary<ScanRootId, ScanRootSnapshotView> { [scanRootId] = rootSnapshot },
+            ScanRoots = new Dictionary<ScanRootId, ScanRoot>
+            {
+                [scanRootId] = new()
+                {
+                    RootId = scanRootId,
+                    DirId = dirs[0].DirId,
+                    RootPath = rootPath,
+                    IsDeleted = false,
+                    CreatedAt = default
+                }
+            }
+        };
+    }
+
+    internal static void SeedFileDir(FakeFileDirReadModel fileDir, RepoSnapshotView snapshot)
+    {
+        foreach (var (scanRootId, root) in snapshot.Snapshots)
+        {
+            for (var i = 0; i < root.Dirs.Count; i++)
+            {
+                var handle = new DirHandle(scanRootId, i);
+                var rec = root.Dirs[i];
+                var path = BuildDirPath(snapshot, handle);
+
+                fileDir.DirHandlesById[rec.DirId] = handle;
+                fileDir.DirPathsByHandle[handle] = path;
+                fileDir.DirPathsById[rec.DirId] = path;
+            }
+
+            for (var i = 0; i < root.Files.Count; i++)
+            {
+                var handle = new FileHandle(scanRootId, i);
+                var rec = root.Files[i];
+                var path = rec.FileId.ToString();
+
+                fileDir.FileHandlesById[rec.FileId] = handle;
+                fileDir.FilePathsByHandle[handle] = path;
+                fileDir.FilePathsById[rec.FileId] = path;
+            }
+        }
+    }
+
+    internal static FakeTreeIndex BuildTreeIndex(RepoSnapshotView snapshot)
+    {
+        var childDirsByParent = new Dictionary<DirHandle, DirHandle[]>();
+        var childFilesByParent = new Dictionary<DirHandle, FileHandle[]>();
+        var statsByDir = new Dictionary<DirHandle, DirAggregateStats>();
+
+        foreach (var (scanRootId, root) in snapshot.Snapshots)
+        {
+            for (var i = 0; i < root.Dirs.Count; i++)
+            {
+                var handle = new DirHandle(scanRootId, i);
+                childDirsByParent[handle] = [];
+                childFilesByParent[handle] = [];
+            }
+
+            for (var i = 0; i < root.Dirs.Count; i++)
+            {
+                var handle = new DirHandle(scanRootId, i);
+                var rec = root.Dirs[i];
+
+                if (rec.ParentDirId < 0)
+                    continue;
+
+                if (!TryGetDirHandle(snapshot, scanRootId, rec.ParentDirId, out var parent))
+                    continue;
+
+                childDirsByParent[parent] = [.. childDirsByParent[parent], handle];
+            }
+
+            for (var i = 0; i < root.Files.Count; i++)
+            {
+                var handle = new FileHandle(scanRootId, i);
+                var rec = root.Files[i];
+
+                if (!TryGetDirHandle(snapshot, scanRootId, rec.DirId, out var parent))
+                    continue;
+
+                childFilesByParent[parent] = [.. childFilesByParent[parent], handle];
+            }
+        }
+
+        foreach (var dir in childDirsByParent.Keys)
+            statsByDir[dir] = ComputeStats(dir);
+
+        return new FakeTreeIndex()
+        {
+            GetChildDirsImpl = dir =>
+                childDirsByParent.TryGetValue(dir, out var children)
+                    ? children
+                    : ReadOnlySpan<DirHandle>.Empty,
+            GetChildFilesImpl = dir =>
+                childFilesByParent.TryGetValue(dir, out var files)
+                    ? files
+                    : ReadOnlySpan<FileHandle>.Empty,
+            GetDirStatsImpl = dir =>
+                statsByDir.TryGetValue(dir, out var stats)
+                    ? stats
+                    : new DirAggregateStats
+                    {
+                        TotalBytes = 0,
+                        FileCount = 0,
+                        DirCount = 0,
+                        DuplicateFiles = 0,
+                        DuplicateBytes = 0
+                    }
+        };
+
+        DirAggregateStats ComputeStats(DirHandle dir)
+        {
+            var childDirs = childDirsByParent.TryGetValue(dir, out var dirs) ? dirs : [];
+            var childFiles = childFilesByParent.TryGetValue(dir, out var files) ? files : [];
+
+            var totalDirs = childDirs.Length;
+            var totalFiles = childFiles.Length;
+            long totalBytes = childFiles.Length * 100L;
+
+            foreach (var child in childDirs)
+            {
+                var childStats = ComputeStats(child);
+                totalDirs += childStats.DirCount;
+                totalFiles += childStats.FileCount;
+                totalBytes += childStats.TotalBytes;
+            }
+
+            return new DirAggregateStats
+            {
+                DirCount = totalDirs,
+                FileCount = totalFiles,
+                TotalBytes = totalBytes,
+                DuplicateFiles = 0,
+                DuplicateBytes = 0
+            };
+        }
+    }
+
+    internal static bool TryGetDirHandle(
+        RepoSnapshotView snapshot,
+        ScanRootId scanRootId,
+        DirId dirId,
+        out DirHandle handle)
+    {
+        var dirs = snapshot.Snapshots[scanRootId].Dirs;
+        for (var i = 0; i < dirs.Count; i++)
+        {
+            if (dirs[i].DirId != dirId)
+                continue;
+
+            handle = new DirHandle(scanRootId, i);
+            return true;
+        }
+
+        handle = DirHandle.Invalid;
+        return false;
+    }
+
+    internal static string BuildDirPath(RepoSnapshotView snapshot, DirHandle handle)
+    {
+        var parts = new Stack<string>();
+        var current = handle;
+
+        while (true)
+        {
+            var rec = snapshot.GetDirRecord(current);
+            var name = snapshot.DecodeDirName(current);
+            if (!string.IsNullOrWhiteSpace(name))
+                parts.Push(name);
+
+            if (rec.ParentDirId < 0)
+                break;
+
+            if (!TryGetDirHandle(snapshot, current.ScanRootId, rec.ParentDirId, out current))
+                break;
+        }
+
+        return string.Join("/", parts);
+    }
+
+    internal static FakeHashIndex BuildEmptyHashIndex()
+    {
+        return new FakeHashIndex
+        {
+            GetGroupsPageImpl = (_, _, _) => new DuplicateGroupPage(0, 0, ReadOnlyMemory<HashGroupDescriptor>.Empty),
+            GetGroupsPageWithFilterImpl = (_, _, _, _) => new DuplicateGroupPage(0, 0, ReadOnlyMemory<HashGroupDescriptor>.Empty),
+            GetGroupFilesImpl = _ => ReadOnlySpan<FileHandle>.Empty
+        };
+    }
+}

--- a/DuplicateFileFinder.GuiTests/Features/Duplicates/TestSupport/DuplicatesSelectionTestHelpers.cs
+++ b/DuplicateFileFinder.GuiTests/Features/Duplicates/TestSupport/DuplicatesSelectionTestHelpers.cs
@@ -182,28 +182,28 @@ internal static class DuplicatesSelectionTestHelpers
             var childDirs = childDirsByParent.TryGetValue(dir, out var dirs) ? dirs : [];
             var childFiles = childFilesByParent.TryGetValue(dir, out var files) ? files : [];
 
-        var totalDirs = childDirs.Length;
-        var totalFiles = childFiles.Length;
-        long totalBytes = childFiles.Length == 0 ? 0 : childFiles.Length * 100L;
+            var totalDirs = childDirs.Length;
+            var totalFiles = childFiles.Length;
+            long totalBytes = childFiles.Length == 0 ? 0 : childFiles.Length * 100L;
 
-        foreach (var child in childDirs)
-        {
-            var childStats = ComputeStats(child);
-            totalDirs += childStats.DirCount;
-            totalFiles += childStats.FileCount;
-            totalBytes += childStats.TotalBytes;
+            foreach (var child in childDirs)
+            {
+                var childStats = ComputeStats(child);
+                totalDirs += childStats.DirCount;
+                totalFiles += childStats.FileCount;
+                totalBytes += childStats.TotalBytes;
+            }
+
+            return new DirAggregateStats
+            {
+                DirCount = totalDirs,
+                FileCount = totalFiles,
+                TotalBytes = totalBytes,
+                DuplicateFiles = 0,
+                DuplicateBytes = 0
+            };
         }
-
-        return new DirAggregateStats
-        {
-            DirCount = totalDirs,
-            FileCount = totalFiles,
-            TotalBytes = totalBytes,
-            DuplicateFiles = 0,
-            DuplicateBytes = 0
-        };
     }
-}
 
     internal static bool TryGetDirHandle(
         RepoSnapshotView snapshot,

--- a/DuplicateFileFinder.GuiTests/Features/Duplicates/TreeMap/TreeMapSelectionSyncTests.cs
+++ b/DuplicateFileFinder.GuiTests/Features/Duplicates/TreeMap/TreeMapSelectionSyncTests.cs
@@ -1,0 +1,120 @@
+using DuplicateFileFinder.Gui.Features.Duplicates.Application;
+using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.TreeMap;
+using DuplicateFileFinder.Gui.Infrastructure.Util;
+using DuplicateFileFinder.GuiTests.Features.Duplicates.TestSupport;
+using DuplicateFileFinder.GuiTests.UI.Fakes;
+
+using DuplicateFileFinderLib.Repository.Core.Models;
+using DuplicateFileFinderLib.Repository.Interfaces;
+
+using Moq;
+
+using Xunit;
+
+namespace DuplicateFileFinder.GuiTests.Features.Duplicates.TreeMap;
+
+public sealed class TreeMapSelectionSyncTests
+{
+    [Fact]
+    public void SelectingDirectoryNode_PublishesDirectorySelectionToSharedContext()
+    {
+        var snapshot = DuplicatesSelectionTestHelpers.BuildSnapshot(
+            scanRootId: 1,
+            dirs:
+            [
+                new(100, -1, "root"),
+                new(200, 100, "A")
+            ],
+            files:
+            [
+                new(700, 200, "f.txt", 123)
+            ]);
+
+        var repo = new FakeRepo(snapshot.ScanRoots.Values) { SnapshotToReturn = snapshot };
+        var fileDir = new FakeFileDirReadModel();
+        DuplicatesSelectionTestHelpers.SeedFileDir(fileDir, snapshot);
+
+        var treeIndex = DuplicatesSelectionTestHelpers.BuildTreeIndex(snapshot);
+
+        var host = new Mock<IRepoHost>(MockBehavior.Strict);
+        host.SetupGet(x => x.Repo).Returns(repo);
+        host.SetupGet(x => x.FileDirIndex).Returns(fileDir);
+        host.SetupGet(x => x.TreeIndex).Returns(treeIndex);
+        host.SetupGet(x => x.HashIndex).Returns(DuplicatesSelectionTestHelpers.BuildEmptyHashIndex());
+
+        var selectionContext = new DuplicateExplorerSelectionContext();
+
+        var vm = new TreeMapController(host.Object, selectionContext, new DisposableManager())
+        {
+            Metric = TreeMapMetric.TotalFiles,
+            Options = new TreeMapBuildOptions
+            {
+                MaxDepth = 8,
+                MaxSubdirsPerDir = 64,
+                MaxFilesPerDir = 64,
+                MaxTotalFileNodes = 1024
+            }
+        };
+
+        vm.Rebuild(snapshot);
+
+        Assert.True(DuplicatesSelectionTestHelpers.TryGetDirHandle(snapshot, 1, 200, out var dir200));
+        vm.SelectedNode = vm.DirNodeByHandle[dir200];
+
+        var current = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(selectionContext.Current);
+        Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.Directory, current.Kind);
+        Assert.Equal(200, current.DirId);
+        Assert.Equal(100, current.ParentDirId);
+    }
+
+    [Fact]
+    public void SelectingFileNode_PublishesFileSelectionToSharedContext()
+    {
+        var snapshot = DuplicatesSelectionTestHelpers.BuildSnapshot(
+            scanRootId: 1,
+            dirs:
+            [
+                new(100, -1, "root"),
+                new(200, 100, "A")
+            ],
+            files:
+            [
+                new(700, 200, "f.txt", 123)
+            ]);
+
+        var repo = new FakeRepo(snapshot.ScanRoots.Values) { SnapshotToReturn = snapshot };
+        var fileDir = new FakeFileDirReadModel();
+        DuplicatesSelectionTestHelpers.SeedFileDir(fileDir, snapshot);
+
+        var treeIndex = DuplicatesSelectionTestHelpers.BuildTreeIndex(snapshot);
+
+        var host = new Mock<IRepoHost>(MockBehavior.Strict);
+        host.SetupGet(x => x.Repo).Returns(repo);
+        host.SetupGet(x => x.FileDirIndex).Returns(fileDir);
+        host.SetupGet(x => x.TreeIndex).Returns(treeIndex);
+        host.SetupGet(x => x.HashIndex).Returns(DuplicatesSelectionTestHelpers.BuildEmptyHashIndex());
+
+        var selectionContext = new DuplicateExplorerSelectionContext();
+
+        var vm = new TreeMapController(host.Object, selectionContext, new DisposableManager())
+        {
+            Options = new TreeMapBuildOptions
+            {
+                MaxDepth = 8,
+                MaxSubdirsPerDir = 64,
+                MaxFilesPerDir = 64,
+                MaxTotalFileNodes = 1024
+            }
+        };
+
+        vm.Rebuild(snapshot);
+
+        var file700 = new FileHandle(1, 0);
+        vm.SelectedNode = vm.FileNodeByHandle[file700];
+
+        var current = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(selectionContext.Current);
+        Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.File, current.Kind);
+        Assert.Equal(700, current.FileId);
+        Assert.Equal(200, current.ParentDirId);
+    }
+}

--- a/DuplicateFileFinder.GuiTests/Features/Duplicates/TreeMap/TreeMapSelectionSyncTests.cs
+++ b/DuplicateFileFinder.GuiTests/Features/Duplicates/TreeMap/TreeMapSelectionSyncTests.cs
@@ -148,7 +148,7 @@ public sealed class TreeMapSelectionSyncTests
         }
 
         return null;
-}
+    }
 
     private static IEnumerable<TreeMapNode<ITreeMapNodeElement>> Traverse(TreeMapNode<ITreeMapNodeElement> root)
     {

--- a/DuplicateFileFinder.GuiTests/Features/Duplicates/TreeMap/TreeMapSelectionSyncTests.cs
+++ b/DuplicateFileFinder.GuiTests/Features/Duplicates/TreeMap/TreeMapSelectionSyncTests.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+
+using DuplicateFileFinder.Gui.Controls.TreeMap;
 using DuplicateFileFinder.Gui.Features.Duplicates.Application;
 using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.TreeMap;
 using DuplicateFileFinder.Gui.Infrastructure.Util;
@@ -5,9 +8,6 @@ using DuplicateFileFinder.GuiTests.Features.Duplicates.TestSupport;
 using DuplicateFileFinder.GuiTests.UI.Fakes;
 
 using DuplicateFileFinderLib.Repository.Core.Models;
-using DuplicateFileFinderLib.Repository.Interfaces;
-
-using Moq;
 
 using Xunit;
 
@@ -30,23 +30,29 @@ public sealed class TreeMapSelectionSyncTests
                 new(700, 200, "f.txt", 123)
             ]);
 
-        var repo = new FakeRepo(snapshot.ScanRoots.Values) { SnapshotToReturn = snapshot };
+        var repo = new FakeRepo(snapshot.ScanRoots.Values)
+        {
+            SnapshotToReturn = snapshot
+        };
+
         var fileDir = new FakeFileDirReadModel();
-        DuplicatesSelectionTestHelpers.SeedFileDir(fileDir, snapshot);
+        DuplicatesSelectionTestHelpers.ResetAndSeedFileDir(fileDir, snapshot);
 
-        var treeIndex = DuplicatesSelectionTestHelpers.BuildTreeIndex(snapshot);
+        var treeIndex = new FakeTreeIndex();
+        DuplicatesSelectionTestHelpers.ConfigureTreeIndex(treeIndex, snapshot);
 
-        var host = new Mock<IRepoHost>(MockBehavior.Strict);
-        host.SetupGet(x => x.Repo).Returns(repo);
-        host.SetupGet(x => x.FileDirIndex).Returns(fileDir);
-        host.SetupGet(x => x.TreeIndex).Returns(treeIndex);
-        host.SetupGet(x => x.HashIndex).Returns(DuplicatesSelectionTestHelpers.BuildEmptyHashIndex());
+        var host = new FakeRepoHost(repo)
+        {
+            FileDirIndex = fileDir,
+            TreeIndex = treeIndex,
+            HashIndex = new FakeHashIndex()
+        };
 
         var selectionContext = new DuplicateExplorerSelectionContext();
 
-        var vm = new TreeMapController(host.Object, selectionContext, new DisposableManager())
+        var vm = new TreeMapController(host, selectionContext, new DisposableManager())
         {
-            Metric = TreeMapMetric.TotalFiles,
+            Metric = TreeMapMetric.TotalBytes,
             Options = new TreeMapBuildOptions
             {
                 MaxDepth = 8,
@@ -63,8 +69,8 @@ public sealed class TreeMapSelectionSyncTests
 
         var current = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(selectionContext.Current);
         Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.Directory, current.Kind);
-        Assert.Equal(200, current.DirId);
-        Assert.Equal(100, current.ParentDirId);
+        Assert.Equal(200, current.ContextDirectoryId);
+        Assert.Equal(100, current.ParentOfContextDirectoryId);
     }
 
     [Fact]
@@ -82,22 +88,29 @@ public sealed class TreeMapSelectionSyncTests
                 new(700, 200, "f.txt", 123)
             ]);
 
-        var repo = new FakeRepo(snapshot.ScanRoots.Values) { SnapshotToReturn = snapshot };
+        var repo = new FakeRepo(snapshot.ScanRoots.Values)
+        {
+            SnapshotToReturn = snapshot
+        };
+
         var fileDir = new FakeFileDirReadModel();
-        DuplicatesSelectionTestHelpers.SeedFileDir(fileDir, snapshot);
+        DuplicatesSelectionTestHelpers.ResetAndSeedFileDir(fileDir, snapshot);
 
-        var treeIndex = DuplicatesSelectionTestHelpers.BuildTreeIndex(snapshot);
+        var treeIndex = new FakeTreeIndex();
+        DuplicatesSelectionTestHelpers.ConfigureTreeIndex(treeIndex, snapshot);
 
-        var host = new Mock<IRepoHost>(MockBehavior.Strict);
-        host.SetupGet(x => x.Repo).Returns(repo);
-        host.SetupGet(x => x.FileDirIndex).Returns(fileDir);
-        host.SetupGet(x => x.TreeIndex).Returns(treeIndex);
-        host.SetupGet(x => x.HashIndex).Returns(DuplicatesSelectionTestHelpers.BuildEmptyHashIndex());
+        var host = new FakeRepoHost(repo)
+        {
+            FileDirIndex = fileDir,
+            TreeIndex = treeIndex,
+            HashIndex = new FakeHashIndex()
+        };
 
         var selectionContext = new DuplicateExplorerSelectionContext();
 
-        var vm = new TreeMapController(host.Object, selectionContext, new DisposableManager())
+        var vm = new TreeMapController(host, selectionContext, new DisposableManager())
         {
+            Metric = TreeMapMetric.TotalBytes,
             Options = new TreeMapBuildOptions
             {
                 MaxDepth = 8,
@@ -110,11 +123,41 @@ public sealed class TreeMapSelectionSyncTests
         vm.Rebuild(snapshot);
 
         var file700 = new FileHandle(1, 0);
-        vm.SelectedNode = vm.FileNodeByHandle[file700];
+        var fileNode = FindFileNode(vm.Root, file700);
+
+        Assert.NotNull(fileNode);
+        vm.SelectedNode = fileNode;
 
         var current = Assert.IsType<DuplicateExplorerSelectionContext.SelectionTarget>(selectionContext.Current);
         Assert.Equal(DuplicateExplorerSelectionContext.SelectionKind.File, current.Kind);
         Assert.Equal(700, current.FileId);
-        Assert.Equal(200, current.ParentDirId);
+        Assert.Equal(200, current.ContextDirectoryId);
+    }
+
+    private static TreeMapNode<ITreeMapNodeElement>? FindFileNode(
+        TreeMapNode<ITreeMapNodeElement>? root,
+        FileHandle file)
+    {
+        if (root is null)
+            return null;
+
+        foreach (var node in Traverse(root))
+        {
+            if (node.Element is FileTreeMapElement fileElement && fileElement.File == file)
+                return node;
+        }
+
+        return null;
+}
+
+    private static IEnumerable<TreeMapNode<ITreeMapNodeElement>> Traverse(TreeMapNode<ITreeMapNodeElement> root)
+    {
+        yield return root;
+
+        foreach (var child in root.Children)
+        {
+            foreach (var descendant in Traverse(child))
+                yield return descendant;
+        }
     }
 }

--- a/DuplicateFileFinder.GuiTests/UI/Fakes/FakeFileDirReadModel.cs
+++ b/DuplicateFileFinder.GuiTests/UI/Fakes/FakeFileDirReadModel.cs
@@ -79,4 +79,21 @@ public sealed class FakeFileDirReadModel : IFileDirReadModel
 
         return FilePathsByHandle.TryGetValue(handle, out rel!);
     }
+
+    public void Reset()
+    {
+        DirHandlesById.Clear();
+        FileHandlesById.Clear();
+        DirPathsByHandle.Clear();
+        FilePathsByHandle.Clear();
+        DirPathsById.Clear();
+        FilePathsById.Clear();
+
+        TryGetFileImpl = null;
+        TryGetDirImpl = null;
+        TryGetDirPathByHandleImpl = null;
+        TryGetFilePathByHandleImpl = null;
+        TryGetDirPathByIdImpl = null;
+        TryGetFilePathByIdImpl = null;
+    }
 }

--- a/DuplicateFileFinder.GuiTests/UI/Fakes/FakeFileDirReadModel.cs
+++ b/DuplicateFileFinder.GuiTests/UI/Fakes/FakeFileDirReadModel.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 
 using DuplicateFileFinderLib.Repository.Core.Models;
 using DuplicateFileFinderLib.Repository.Plugins.Interfaces;
@@ -11,44 +11,72 @@ public sealed class FakeFileDirReadModel : IFileDirReadModel
     public delegate bool TryGetDirPathByHandleDelegate(DirHandle handle, out string rel);
     public delegate bool TryGetFilePathByHandleDelegate(FileHandle handle, out string rel);
     public delegate bool TryGetFileDelegate(FileId fileId, out FileHandle handle);
+    public delegate bool TryGetDirDelegate(DirId dirId, out DirHandle handle);
+    public delegate bool TryGetDirPathByIdDelegate(DirId dirId, out string rel);
+    public delegate bool TryGetFilePathByIdDelegate(FileId fileId, out string rel);
 
     public TryGetFileDelegate? TryGetFileImpl { get; set; }
-    public TryGetDirPathByHandleDelegate? TryGetDirPathByHandleImpl { get; init; }
-    public TryGetFilePathByHandleDelegate? TryGetFilePathByHandleImpl { get; init; }
+    public TryGetDirDelegate? TryGetDirImpl { get; set; }
+    public TryGetDirPathByHandleDelegate? TryGetDirPathByHandleImpl { get; set; }
+    public TryGetFilePathByHandleDelegate? TryGetFilePathByHandleImpl { get; set; }
+    public TryGetDirPathByIdDelegate? TryGetDirPathByIdImpl { get; set; }
+    public TryGetFilePathByIdDelegate? TryGetFilePathByIdImpl { get; set; }
 
-    public bool TryGetDirPathById(DirId dirId, out string relativePath) => throw new NotImplementedException();
+    public Dictionary<DirId, DirHandle> DirHandlesById { get; } = [];
+    public Dictionary<FileId, FileHandle> FileHandlesById { get; } = [];
+    public Dictionary<DirHandle, string> DirPathsByHandle { get; } = [];
+    public Dictionary<FileHandle, string> FilePathsByHandle { get; } = [];
+    public Dictionary<DirId, string> DirPathsById { get; } = [];
+    public Dictionary<FileId, string> FilePathsById { get; } = [];
+
+    public bool TryGetDirPathById(DirId dirId, out string relativePath)
+    {
+        if (TryGetDirPathByIdImpl is not null)
+            return TryGetDirPathByIdImpl(dirId, out relativePath);
+
+        return DirPathsById.TryGetValue(dirId, out relativePath!);
+    }
 
     public bool TryGetDirPathByHandle(DirHandle handle, out string rel)
     {
         if (TryGetDirPathByHandleImpl is not null)
             return TryGetDirPathByHandleImpl(handle, out rel);
 
-        rel = "";
-        return false;
+        return DirPathsByHandle.TryGetValue(handle, out rel!);
     }
 
-    public bool TryGetDir(DirId dirId, out DirHandle handle) => throw new NotImplementedException();
+    public bool TryGetDir(DirId dirId, out DirHandle handle)
+    {
+        if (TryGetDirImpl is not null)
+            return TryGetDirImpl(dirId, out handle);
+
+        return DirHandlesById.TryGetValue(dirId, out handle);
+    }
 
     public bool TryGetFile(FileId fileId, out FileHandle handle)
     {
         if (TryGetFileImpl is not null)
             return TryGetFileImpl(fileId, out handle);
 
-        handle = default;
-        return false;
+        return FileHandlesById.TryGetValue(fileId, out handle);
     }
 
-    public int FileCount { get; }
-    public int DirCount { get; }
+    public int FileCount => FileHandlesById.Count;
+    public int DirCount => DirHandlesById.Count;
 
-    public bool TryGetFilePathById(FileId fileId, out string relativePath) => throw new NotImplementedException();
+    public bool TryGetFilePathById(FileId fileId, out string relativePath)
+    {
+        if (TryGetFilePathByIdImpl is not null)
+            return TryGetFilePathByIdImpl(fileId, out relativePath);
+
+        return FilePathsById.TryGetValue(fileId, out relativePath!);
+    }
 
     public bool TryGetFilePathByHandle(FileHandle handle, out string rel)
     {
         if (TryGetFilePathByHandleImpl is not null)
             return TryGetFilePathByHandleImpl(handle, out rel);
 
-        rel = "";
-        return false;
+        return FilePathsByHandle.TryGetValue(handle, out rel!);
     }
 }

--- a/DuplicateFileFinder.GuiTests/UI/Fakes/FakeHashIndex.cs
+++ b/DuplicateFileFinder.GuiTests/UI/Fakes/FakeHashIndex.cs
@@ -1,0 +1,38 @@
+using System;
+
+using DuplicateFileFinderLib.Repository.Core.Models;
+using DuplicateFileFinderLib.Repository.Plugins.Interfaces;
+using DuplicateFileFinderLib.Repository.Plugins.Models;
+
+namespace DuplicateFileFinder.GuiTests.UI.Fakes;
+
+public sealed class FakeHashIndex : IHashIndexReadModel
+{
+    public Func<DuplicateQuery, int, int, DuplicateGroupPage>? GetGroupsPageImpl { get; set; }
+    public GetGroupsPageWithFilterDelegate? GetGroupsPageWithFilterImpl { get; set; }
+    public Func<HashGroupDescriptor, ReadOnlySpan<FileHandle>>? GetGroupFilesImpl { get; set; }
+
+    public delegate DuplicateGroupPage GetGroupsPageWithFilterDelegate(
+        DuplicateQuery query,
+        SubtreeFilter filter,
+        int offset,
+        int count);
+
+    public DuplicateGroupPage GetGroupsPage(in DuplicateQuery query, int offset, int count) =>
+        GetGroupsPageImpl?.Invoke(query, offset, count)
+        ?? new DuplicateGroupPage(0, 0, ReadOnlyMemory<HashGroupDescriptor>.Empty);
+
+    public DuplicateGroupPage GetGroupsPage(
+        in DuplicateQuery query,
+        in SubtreeFilter filter,
+        int offset,
+        int count) =>
+        GetGroupsPageWithFilterImpl?.Invoke(query, filter, offset, count)
+        ?? new DuplicateGroupPage(0, 0, ReadOnlyMemory<HashGroupDescriptor>.Empty);
+
+    public ReadOnlySpan<FileHandle> GetGroupFiles(in HashGroupDescriptor group) =>
+        GetGroupFilesImpl is not null ? GetGroupFilesImpl.Invoke(group) : ReadOnlySpan<FileHandle>.Empty;
+
+    public int TotalDuplicateFileCount { get; init; }
+    public long TotalSpaceTakenByDuplicates { get; init; }
+}

--- a/DuplicateFileFinder.GuiTests/UI/Fakes/FakeHashIndex.cs
+++ b/DuplicateFileFinder.GuiTests/UI/Fakes/FakeHashIndex.cs
@@ -35,4 +35,11 @@ public sealed class FakeHashIndex : IHashIndexReadModel
 
     public int TotalDuplicateFileCount { get; init; }
     public long TotalSpaceTakenByDuplicates { get; init; }
+
+    public void Reset()
+    {
+        GetGroupsPageImpl = null;
+        GetGroupsPageWithFilterImpl = null;
+        GetGroupFilesImpl = null;
+    }
 }

--- a/DuplicateFileFinder.GuiTests/UI/Fakes/FakeRepo.cs
+++ b/DuplicateFileFinder.GuiTests/UI/Fakes/FakeRepo.cs
@@ -21,6 +21,8 @@ public sealed class FakeRepo(IEnumerable<ScanRoot>? scanRoots = null) : IRepo
 
     public Dictionary<string, object> ReturnResultFor { get; } = new();
 
+    public RepoSnapshotView? SnapshotToReturn { get; set; }
+
     private T? Result<T>(T? defaultValue = default, [CallerMemberName] string memberName = "")
     {
         if (!ReturnResultFor.TryGetValue(memberName, out var result))
@@ -39,19 +41,32 @@ public sealed class FakeRepo(IEnumerable<ScanRoot>? scanRoots = null) : IRepo
 
     public IReadOnlyList<ScanRun> ScanRunsView => _scanRuns;
     public IReadOnlyList<ScanRoot> ScanRootsView => _scanRoots;
-    // ReSharper disable once ReturnTypeCanBeNotNullable
-    public ScanRootSnapshotView? TryGetScanRootView(ScanRootId scanRootId) => throw new NotImplementedException();
+
+    public ScanRootSnapshotView? TryGetScanRootView(ScanRootId scanRootId)
+    {
+        if (SnapshotToReturn?.Snapshots is null)
+            return null;
+
+        return SnapshotToReturn.Snapshots.GetValueOrDefault(scanRootId);
+    }
 
     public RepoSnapshotView GetRepoSnapshotView()
     {
-        return new RepoSnapshotView
-        {
-            Snapshots = null!,
-            ScanRoots = null!
-        };
+        if (SnapshotToReturn is not null)
+            return SnapshotToReturn;
+
+        return new RepoSnapshotView { Snapshots = null!, ScanRoots = null! };
     }
 
-    public bool HasScanCheckpoint(ScanRootId scanRootId) => throw new NotImplementedException();
+    public HashSet<ScanRootId> ScanRootsWithCheckpoints { get; } = [];
+    public Func<ScanRootId, bool>? HasScanCheckpointImpl { get; set; }
+    public bool HasScanCheckpoint(ScanRootId scanRootId)
+    {
+        if (HasScanCheckpointImpl is not null)
+            return HasScanCheckpointImpl(scanRootId);
+
+        return ScanRootsWithCheckpoints.Contains(scanRootId);
+    }
 
     Task<DeleteResult> IRepo.DeleteFileAsync(FileHandle file, CancellationToken ct)
     {
@@ -76,7 +91,7 @@ public sealed class FakeRepo(IEnumerable<ScanRoot>? scanRoots = null) : IRepo
     public void SetScanRoots(IEnumerable<ScanRoot> scanRoots)
         => _scanRoots = scanRoots.ToList();
 
-    public void Dispose() => throw new NotImplementedException();
+    public void Dispose() { }
 
-    public ValueTask DisposeAsync() => throw new NotImplementedException();
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/DuplicateFileFinder.GuiTests/UI/Fakes/FakeRepoHost.cs
+++ b/DuplicateFileFinder.GuiTests/UI/Fakes/FakeRepoHost.cs
@@ -2,10 +2,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using DuplicateFileFinderLib.Repository.Core.Models;
 using DuplicateFileFinderLib.Repository.Interfaces;
 using DuplicateFileFinderLib.Repository.Plugins.Interfaces;
-using DuplicateFileFinderLib.Repository.Plugins.Models;
 
 // ReSharper disable UnassignedGetOnlyAutoProperty
 
@@ -16,8 +14,9 @@ public sealed class FakeRepoHost(IRepo repo) : IRepoHost
     public IRepo Repo { get; } = repo;
     public IFileDirReadModel FileDirIndex { get; set; } = new FakeFileDirReadModel();
     public long LastIndexedGeneration { get; private set; } = 1;
-    public ITreeIndexReadModel TreeIndex { get; } = new DummyTreeIndex();
-    public IHashIndexReadModel HashIndex { get; } = new DummyHashIndex();
+
+    public ITreeIndexReadModel TreeIndex { get; set; } = new FakeTreeIndex();
+    public IHashIndexReadModel HashIndex { get; set; } = new FakeHashIndex();
 
     public event EventHandler<RepoIndexesRebuiltEventArgs>? IndexesRebuilt;
 
@@ -36,32 +35,4 @@ public sealed class FakeRepoHost(IRepo repo) : IRepoHost
     }
 
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
-
-    private sealed class DummyTreeIndex : ITreeIndexReadModel
-    {
-        public DirAggregateStats GetDirStats(DirHandle dirId) => throw new NotImplementedException();
-
-        public ReadOnlySpan<DirHandle> GetChildDirs(DirHandle dir) => throw new NotImplementedException();
-
-        public ReadOnlySpan<FileHandle> GetChildFiles(DirHandle dir) => throw new NotImplementedException();
-        public bool TryGetSubtreeRange(DirHandle dir, out SubtreeRange range) => throw new NotImplementedException();
-
-        public bool TryGetFileDirPreorder(FileHandle file, out int preorder) => throw new NotImplementedException();
-    }
-
-    private sealed class DummyHashIndex : IHashIndexReadModel
-    {
-        public DuplicateGroupPage GetGroupsPage(in DuplicateQuery query, int offset, int count) =>
-            throw new NotImplementedException();
-
-        public DuplicateGroupPage
-            GetGroupsPage(in DuplicateQuery query, in SubtreeFilter filter, int offset, int count) =>
-            throw new NotImplementedException();
-
-        public ReadOnlySpan<FileHandle> GetGroupFiles(in HashGroupDescriptor group) =>
-            throw new NotImplementedException();
-
-        public int TotalDuplicateFileCount { get; }
-        public long TotalSpaceTakenByDuplicates { get; }
-    }
 }

--- a/DuplicateFileFinder.GuiTests/UI/Fakes/FakeTreeIndex.cs
+++ b/DuplicateFileFinder.GuiTests/UI/Fakes/FakeTreeIndex.cs
@@ -1,0 +1,53 @@
+using System;
+
+using DuplicateFileFinderLib.Repository.Core.Models;
+using DuplicateFileFinderLib.Repository.Plugins.Interfaces;
+using DuplicateFileFinderLib.Repository.Plugins.Models;
+
+namespace DuplicateFileFinder.GuiTests.UI.Fakes;
+
+public sealed class FakeTreeIndex : ITreeIndexReadModel
+{
+    public Func<DirHandle, DirAggregateStats>? GetDirStatsImpl { get; set; }
+    public Func<DirHandle, ReadOnlySpan<DirHandle>>? GetChildDirsImpl { get; set; }
+    public Func<DirHandle, ReadOnlySpan<FileHandle>>? GetChildFilesImpl { get; set; }
+    public TryGetSubtreeRangeDelegate? TryGetSubtreeRangeImpl { get; set; }
+    public TryGetFileDirPreorderDelegate? TryGetFileDirPreorderImpl { get; set; }
+
+    public delegate bool TryGetSubtreeRangeDelegate(DirHandle dir, out SubtreeRange range);
+    public delegate bool TryGetFileDirPreorderDelegate(FileHandle file, out int preorder);
+
+    public DirAggregateStats GetDirStats(DirHandle dirId) =>
+        GetDirStatsImpl?.Invoke(dirId) ?? new DirAggregateStats
+        {
+            TotalBytes = 0,
+            FileCount = 0,
+            DirCount = 0,
+            DuplicateFiles = 0,
+            DuplicateBytes = 0
+        };
+
+    public ReadOnlySpan<DirHandle> GetChildDirs(DirHandle dir) =>
+        GetChildDirsImpl is not null ? GetChildDirsImpl.Invoke(dir) : ReadOnlySpan<DirHandle>.Empty;
+
+    public ReadOnlySpan<FileHandle> GetChildFiles(DirHandle dir) =>
+        GetChildFilesImpl is not null ? GetChildFilesImpl.Invoke(dir) : ReadOnlySpan<FileHandle>.Empty;
+
+    public bool TryGetSubtreeRange(DirHandle dir, out SubtreeRange range)
+    {
+        if (TryGetSubtreeRangeImpl is not null)
+            return TryGetSubtreeRangeImpl(dir, out range);
+
+        range = default;
+        return false;
+    }
+
+    public bool TryGetFileDirPreorder(FileHandle file, out int preorder)
+    {
+        if (TryGetFileDirPreorderImpl is not null)
+            return TryGetFileDirPreorderImpl(file, out preorder);
+
+        preorder = 0;
+        return false;
+    }
+}

--- a/DuplicateFileFinder.GuiTests/UI/Fakes/FakeTreeIndex.cs
+++ b/DuplicateFileFinder.GuiTests/UI/Fakes/FakeTreeIndex.cs
@@ -50,4 +50,13 @@ public sealed class FakeTreeIndex : ITreeIndexReadModel
         preorder = 0;
         return false;
     }
+
+    public void Reset()
+    {
+        GetDirStatsImpl = null;
+        GetChildDirsImpl = null;
+        GetChildFilesImpl = null;
+        TryGetSubtreeRangeImpl = null;
+        TryGetFileDirPreorderImpl = null;
+    }
 }

--- a/DuplicateFileFinder.GuiTests/UI/Smoke/DuplicatesViewSmokeTests.cs
+++ b/DuplicateFileFinder.GuiTests/UI/Smoke/DuplicatesViewSmokeTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.VisualTree;
 
+using DuplicateFileFinder.Gui.Features.Duplicates.Application;
 using DuplicateFileFinder.Gui.Features.Duplicates.Application.ScanRootsTree;
 using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels;
 using DuplicateFileFinder.Gui.Features.Duplicates.ViewModels.DuplicateGroups;
@@ -55,10 +56,17 @@ public sealed class DuplicatesViewSmokeTests
             builder: scanRootsBuilder,
             actions: scanRootsActions,
             deletionService: fakeDeletionService,
-            disposer: new DisposableManager());
+            disposer: new DisposableManager(),
+            selectionContext: new DuplicateExplorerSelectionContext());
 
         // ---- TreeMap ----
-        var treeMapController = new TreeMapController(host) { Options = new TreeMapBuildOptions { MaxDepth = 8 } };
+        var treeMapController = new TreeMapController(
+            host,
+            new DuplicateExplorerSelectionContext(),
+            new DisposableManager())
+        {
+            Options = new TreeMapBuildOptions { MaxDepth = 8 }
+        };
 
         var treeMapActionsVm = new TreeMapActionsViewModel(
             host,
@@ -72,7 +80,9 @@ public sealed class DuplicatesViewSmokeTests
             scanRootsVm,
             treeMapController,
             treeMapActionsVm,
-            duplicateGroupsVm);
+            duplicateGroupsVm,
+            new DuplicateExplorerSelectionContext(),
+            new DisposableManager());
 
         var view = new DuplicatesView { DataContext = vm };
 

--- a/DuplicateFileFinder.GuiTests/UI/Smoke/DuplicatesViewSmokeTests.cs
+++ b/DuplicateFileFinder.GuiTests/UI/Smoke/DuplicatesViewSmokeTests.cs
@@ -52,6 +52,7 @@ public sealed class DuplicatesViewSmokeTests
             clipboard: fakeClipboardService);
 
         var scanRootsVm = new ScanRootsTreeViewModel(
+            host,
             repoEvents: repoEventRelay,
             builder: scanRootsBuilder,
             actions: scanRootsActions,


### PR DESCRIPTION
Add shared selection state for treeview and treemap.
Add some unit tests for the selection synchronisation.
Ensure selection state is re-applied after repo mutation and UI rebuild.